### PR TITLE
Use provided Google Sheet for logging

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -7,7 +7,8 @@
  * 1.  Deploy as a Web App → “Execute as Me”, “Anyone”.
  * 2.  Add your Sheet ID below or create one named “StainBlasterLog”.
  */
-const SHEET_ID   = 'YOUR_SHEET_ID_HERE';   // ← update
+// Google Sheet used for logging game results
+const SHEET_ID   = '17k6TfJeAERydKa0L0vAXRp6y0q3zckB35dFv9qfDQ6g';
 const SHEET_NAME = 'StainBlasterLog';
 
 /** Serve the kiosk page */

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ An ✨ 15-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 * **Google Sheets** – prize logging for marketing analytics.
 
 ## Quick Start
-1. Create (or reuse) a Google Sheet; note its ID.  
-2. In Apps Script, paste `Code.gs`, set `SHEET_ID`.  
-3. Add an **HTML** file named `index` and paste `index.html`.  
-4. **Deploy → New Web App** “Execute as Me”, “Anyone”, copy URL.  
-5. Point EloView/Yodeck to this URL (ensure portrait 1080×1920).  
+1. The provided `Code.gs` logs to [this Google Sheet](https://docs.google.com/spreadsheets/d/17k6TfJeAERydKa0L0vAXRp6y0q3zckB35dFv9qfDQ6g/edit) by default.
+2. If using a different spreadsheet, update the `SHEET_ID` constant in `Code.gs`.
+3. Add an **HTML** file named `index` and paste `index.html`.
+4. **Deploy → New Web App** “Execute as Me”, “Anyone”, copy URL.
+5. Point EloView/Yodeck to this URL (ensure portrait 1080×1920).
 
 ## Prize Odds
 Default odds live in `index.html`. To adjust without a push, expose them via `logGame` response or a `getConfig()` GAS endpoint, then fetch at runtime.


### PR DESCRIPTION
## Summary
- Configure Google Apps Script backend to log game results to the provided Google Sheet, creating the sheet if missing.
- Document the default spreadsheet in the Quick Start instructions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688def7bcb508322beb0125a41fcf3fe