### PR TITLE
Ensure log sheet initializes with headers

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -22,6 +22,17 @@ function doGet() {
 function logGame(dataJSON) {
   const ss    = SpreadsheetApp.openById(SHEET_ID);
   const sheet = ss.getSheetByName(SHEET_NAME) || ss.insertSheet(SHEET_NAME);
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow([
+      'Timestamp',
+      'Voucher code',
+      'Prize $',
+      'Stains cleared',
+      'Stains missed',
+      'Seconds taken',
+      'Device'
+    ]);
+  }
   const d     = JSON.parse(dataJSON);
   sheet.appendRow([
     new Date(),            // Timestamp


### PR DESCRIPTION
## Summary
- Automatically add column headers when the log sheet is empty so each logged entry is labeled.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dfe69e49083229cf8664d82185108