### PR TITLE
Ensure no leftover stains when winning

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,9 @@
   function win(){
     clearInterval(countdown);
     clearInterval(fireInterval);
-    showResult(true);
+    // Double-check no stain elements remain before allowing a win
+    const stainsLeft = gameArea.querySelectorAll('.stain').length;
+    showResult(stainsLeft === 0);
   }
 
   function lose(){


### PR DESCRIPTION
## Summary
- Double-check for remaining stains before displaying a win screen

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0820187c8322b71fd0491e3c9a18