### PR TITLE
fix: remove leftover cannon overlay code

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,48 +83,6 @@
   const qrWrap      = document.getElementById('qrWrap');
   const logo        = document.getElementById('logo');
   const playBtn     = document.getElementById('playBtn');
-  // keep the cannon layer above other DOM updates
-  const bringCannonFront = () => {
-    if (document.body.lastElementChild !== uiShell) {
-      document.body.appendChild(uiShell);
-    }
-  };
-
-  // Periodically verify the cannon remains visible and properly positioned
-  const checkCannon = () => {
-    if (!document.body.contains(uiShell)) {
-      document.body.appendChild(uiShell);
-    }
-    if (!uiShell.contains(cannon)) {
-      const img = new Image();
-      img.id = 'cannon';
-      img.src = 'https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png';
-      img.alt = 'cannon';
-      img.className = 'select-none';
-      uiShell.appendChild(img);
-      cannon = img;
-    }
-    const rect = cannon.getBoundingClientRect();
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    if (rect.bottom < 0 || rect.right < 0 || rect.top > vh || rect.left > vw || rect.width === 0 || rect.height === 0) {
-      uiShell.style.position = 'fixed';
-      uiShell.style.inset = '0';
-      uiShell.style.pointerEvents = 'none';
-      uiShell.style.zIndex = '2147483647';
-      cannon.style.position = 'fixed';
-      cannon.style.display = 'block';
-      cannon.style.zIndex = '2147483647';
-      cannon.style.top = 'auto';
-      cannon.style.left = 'auto';
-      cannon.style.bottom = '1rem';
-      cannon.style.right = '1rem';
-      cannon.style.transform = 'rotate(0deg)';
-    }
-    bringCannonFront();
-  };
-  setInterval(checkCannon, 1000);
-  checkCannon();
   let remaining, total, seconds, countdown, startTime, fireInterval, bubbleTimer;
 
   function pickPrize(){


### PR DESCRIPTION
## Summary
- strip orphaned cannon overlay logic that referenced undefined `uiShell`
- leave cannon anchored within the game area so play starts correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e1887e5a083229de11ce3539d8fa5