### PR TITLE
Log player geo location

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -17,7 +17,8 @@ const HEADERS = [
   'Stains cleared',
   'Stains missed',
   'Seconds taken',
-  'Device'
+  'Device',
+  'Geo'
 ];
 
 /** Serve the kiosk page */
@@ -44,7 +45,8 @@ function logGame(dataJSON) {
     d.score,               // Stains cleared
     d.missed || 0,         // Stains missed
     d.duration,            // Seconds taken
-    d.device || 'kiosk'    // Device label
+    d.device || 'kiosk',   // Device label
+    d.geo || ''            // Geo location
   ]);
   return true;
 }

--- a/index.html
+++ b/index.html
@@ -83,7 +83,13 @@
   const qrWrap      = document.getElementById('qrWrap');
   const logo        = document.getElementById('logo');
   const playBtn     = document.getElementById('playBtn');
-  let remaining, total, seconds, countdown, startTime, fireInterval, bubbleTimer;
+  let remaining, total, seconds, countdown, startTime, fireInterval, bubbleTimer, geo = '';
+
+  if(navigator.geolocation){
+    navigator.geolocation.getCurrentPosition(pos => {
+      geo = `${pos.coords.latitude},${pos.coords.longitude}`;
+    }, () => { geo = ''; });
+  }
 
   function pickPrize(){
     const r = Math.random();
@@ -235,7 +241,8 @@
       score: total - remaining,
       missed: remaining,
       duration: (Date.now()-startTime)/1000,
-      device:'kiosk'
+      device:'kiosk',
+      geo
     };
     if(success){
       const prize = pickPrize();


### PR DESCRIPTION
## Summary
- capture browser geolocation on the client and include it with game results
- extend server logging to record geo coordinates in a new column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e1aa891588322b0cb992009733808