### PR TITLE
Show cannon image on start screen and enlarge

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <style>
     .stain{position:absolute;width:90px;height:90px;filter:drop-shadow(2px 2px 3px rgba(0,0,0,0.4));z-index:10;}
-    #cannon{position:absolute;width:110px;height:auto;bottom:1rem;right:1rem;transform-origin:bottom right;pointer-events:none;z-index:50;}
+    #cannon{position:absolute;width:220px;height:auto;bottom:1rem;right:1rem;transform-origin:bottom right;pointer-events:none;z-index:50;}
     .bubble{position:absolute;pointer-events:none;}
     .bubble::before{content:"";position:absolute;bottom:-10px;left:50%;transform:translateX(-50%);border-width:10px 10px 0 10px;border-style:solid;border-color:#059669 transparent transparent transparent;}
     .bubble::after{content:"";position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);border-width:8px 8px 0 8px;border-style:solid;border-color:#fff transparent transparent transparent;}
@@ -25,11 +25,12 @@
     <button id="playBtn" class="px-6 py-3 bg-emerald-600 text-white text-2xl rounded-2xl shadow-lg active:scale-95 transition">Play Now</button>
   </div>
 
+  <img id="cannon" src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png" alt="cannon" class="select-none">
+
   <!-- Game Area -->
   <div id="gameArea" class="absolute inset-0 hidden bg-[url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Whiteshirt.png')] bg-cover">
     <!-- stains injected here -->
     <div id="timer" class="absolute top-6 left-1/2 -translate-x-1/2 text-5xl font-bold text-white drop-shadow">12</div>
-    <img id="cannon" src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png" alt="cannon" class="select-none">
   </div>
 
   <!-- Result Screen -->


### PR DESCRIPTION
## Summary
- Display the cannon graphic on the main start screen
- Double the cannon image width for a bigger appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e1b341b948322bc45669f3e8781de