### PR TITLE
Record player geolocation in Stain Blaster logs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -18,7 +18,7 @@ const HEADERS = [
   'Stains missed',
   'Seconds taken',
   'Device',
-  'Geo'
+  'Geo location'
 ];
 
 /** Serve the kiosk page */
@@ -32,8 +32,13 @@ function doGet() {
 function logGame(dataJSON) {
   const ss    = SpreadsheetApp.openById(SHEET_ID);
   const sheet = ss.getSheetByName(SHEET_NAME) || ss.insertSheet(SHEET_NAME);
-  const existingHeaders = sheet.getRange(1, 1, 1, HEADERS.length).getValues()[0];
-  if (existingHeaders.join('') === '') {
+  const existingHeaders = sheet
+    .getRange(1, 1, 1, Math.max(sheet.getLastColumn(), HEADERS.length))
+    .getValues()[0];
+  const headersMismatch = existingHeaders
+    .slice(0, HEADERS.length)
+    .some((h, i) => h !== HEADERS[i]);
+  if (existingHeaders.length < HEADERS.length || headersMismatch) {
     sheet.getRange(1, 1, 1, HEADERS.length).setValues([HEADERS]);
     sheet.setFrozenRows(1); // keep headers visible
   }

--- a/index.html
+++ b/index.html
@@ -86,10 +86,12 @@
   const playBtn     = document.getElementById('playBtn');
   let remaining, total, seconds, countdown, startTime, fireInterval, bubbleTimer, geo = '';
 
-  if(navigator.geolocation){
-    navigator.geolocation.getCurrentPosition(pos => {
-      geo = `${pos.coords.latitude},${pos.coords.longitude}`;
-    }, () => { geo = ''; });
+  function updateGeo(){
+    if(navigator.geolocation){
+      navigator.geolocation.getCurrentPosition(pos => {
+        geo = `${pos.coords.latitude},${pos.coords.longitude}`;
+      }, () => { geo = ''; });
+    }
   }
 
   function pickPrize(){
@@ -201,6 +203,7 @@
     startScreen.classList.add('hidden');
     clearTimeout(bubbleTimer);
     startScreen.querySelectorAll('.bubble').forEach(b=>b.remove());
+    updateGeo();
     gameArea.classList.remove('hidden');
     gameArea.querySelectorAll('.stain').forEach(s=>s.remove());
     if(!gameArea.contains(timerEl)) gameArea.appendChild(timerEl);


### PR DESCRIPTION
## Summary
- request geolocation after the player starts a game to ensure coordinates are captured
- log Google Sheet rows with a new `Geo location` column, updating headers if needed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e1d5732c08322b55e1e7719bbd924