### PR TITLE
feat: mobile-friendly Stain Blaster tweaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Dublin Cleaners “Stain Blaster” Game – Agent Notes
 
 ## Overview
-The **Stain Blaster** mini-game reinforces Dublin Cleaners’ Three Uniques by inviting passers-by to *literally* wipe stains from a shirt in under 15 seconds. Winners instantly receive a QR-encoded gift-certificate, driving in-store redemptions and measurable engagement.
+The **Stain Blaster** mini-game reinforces Dublin Cleaners’ Three Uniques by inviting passers-by to *literally* wipe stains from a shirt in under 12 seconds. Winners instantly receive a QR-encoded gift-certificate, driving in-store redemptions and measurable engagement. The kiosk build targets a 55" portrait Elo display, while the same code adapts to sub‑414 px mobile browsers.
 
 | Core Loop | Tech / Files |
 |-----------|--------------|
-| 1. Attract screen invites touch.<br>2. Fifteen stains appear over a white shirt background.<br>3. Guests tap/slide each stain → it vanishes.<br>4. Clear all within 12 s (including cannon-fired extras) → confetti, prize, QR.<br>5. Lose → friendly “Try again.” | `Code.gs` – GAS backend (log to Sheet).<br>`index.html` – Tailwind kiosk front end.<br>Sheet tab **StainBlasterLog** stores timestamp, voucher, prize, score, missed, duration. |
+| 1. Attract screen invites touch.<br>2. Fifteen stains appear over a white shirt background.<br>3. Guests tap/slide each stain → it vanishes.<br>4. Clear all within 12 s (including cannon-fired extras) → confetti, prize, QR.<br>5. Lose → friendly “Try again.” | `Code.gs` – GAS backend (log to Sheet).<br>`index.html` – Tailwind front end with responsive tweaks.<br>Sheet tab **StainBlasterLog** stores timestamp, voucher, prize, score, missed, duration, device, geo. |
 
 ## Prize Logic
 Weighted probabilities (60 % → $5, 25 % → $10, 10 % → $20, 4 % → $25, 1 % → $50) run **client-side** for snappy UX; results post to GAS where marketing can monitor redemption frequency and tweak weights.
@@ -25,9 +25,10 @@ A 10-line service-worker caches Tailwind CDN, images, and QR/confetti libraries 
 ## Phase 2 Notes
 * Background swaps to a high-res white dress shirt.
 * Stains use semi-transparent PNG splatters (~90 px) with drop shadows.
-* A bottom-right cannon fires additional stains along arced paths every 3 s.
+* A bottom-right cannon fires additional stains along arced paths every 3 s and scales down on phones so the start button stays clear.
 * Timer reduced to 12 s; clearing **all** active stains (initial + fired) yields a win.
-* `logGame` now records `missed` count alongside `score`.
+* Stains shrink ~25 % and spawn across a broader vertical range on phones for extra challenge.
+* `logGame` now records `missed` count alongside `score` and device.
 
 ## Phase 3 Notes
 * Attract mode spawns speech bubbles every ~4 s (±1 s) with playful lines.

--- a/Code.gs
+++ b/Code.gs
@@ -3,6 +3,7 @@
  * Google Apps Script backend (HTML Service)
  * ------------------------------------------
  * Logs game results to a Google Sheet and serves index.html.
+ * Supports both kiosk and mobile plays; client reports device type.
  *
  * 1.  Deploy as a Web App → “Execute as Me”, “Anyone”.
  * 2.  Add your Sheet ID below or create one named “StainBlasterLog”.
@@ -17,7 +18,7 @@ const HEADERS = [
   'Stains cleared',
   'Stains missed',
   'Seconds taken',
-  'Device',
+  'Device',            // 'kiosk' or 'mobile'
   'Geo location'
 ];
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stain Blaster Kiosk Game
 
-An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to win instant, QR‑encoded gift certificates.
+An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to win instant, QR‑encoded gift certificates. The same build now scales down for phones, keeping the cannon visible and shrinking stains for added challenge.
 
 ## Stack
 * **Google Apps Script (HTML Service)** – one `Code.gs` backend.
@@ -44,14 +44,14 @@ Each play logs a row to the Google Sheet with the following columns:
 | D      | Stains cleared | Number of stains the player removed     |
 | E      | Stains missed  | Stains left when time expired           |
 | F      | Seconds taken  | Duration of the game in seconds         |
-| G      | Device         | Source device label (e.g., kiosk)       |
+| G      | Device         | Source device label (kiosk or mobile)   |
 
 Monitor play counts, difficulty, and cost; pivot by day for prize budgeting.
 
 ## Local Assets
 * **Shirt background** – 1080 × 1920 PNG of a pressed white dress shirt.
-* **Stain sprites** – semi-transparent PNG splatters (~90 px) with drop shadow.
-* **Cannon sprite** – small, cartoony launcher anchored bottom-right.
+* **Stain sprites** – semi-transparent PNG splatters (~90 px) with drop shadow; phones render them ~25 % smaller.
+* **Cannon sprite** – small, cartoony launcher anchored bottom-right; shrinks on phones so it never covers the Play button.
 All images can be swapped by editing `index.html`; the service worker caches them for offline play.
 
 ## License

--- a/index.html
+++ b/index.html
@@ -7,8 +7,12 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <style>
-    .stain{position:absolute;width:90px;height:90px;filter:drop-shadow(2px 2px 3px rgba(0,0,0,0.4));z-index:10;}
+    .stain{position:absolute;filter:drop-shadow(2px 2px 3px rgba(0,0,0,0.4));z-index:10;}
     #cannon{position:absolute;width:220px;height:auto;bottom:1rem;right:1rem;transform-origin:bottom right;pointer-events:none;z-index:50;}
+    @media (max-width:414px){
+      #cannon{width:120px;bottom:.5rem;right:.5rem;}
+      #startScreen{padding-bottom:6rem;}
+    }
     .bubble{position:absolute;pointer-events:none;}
     .bubble::before{content:"";position:absolute;bottom:-10px;left:50%;transform:translateX(-50%);border-width:10px 10px 0 10px;border-style:solid;border-color:#059669 transparent transparent transparent;}
     .bubble::after{content:"";position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);border-width:8px 8px 0 8px;border-style:solid;border-color:#fff transparent transparent transparent;}
@@ -47,8 +51,12 @@
   /* ----- Config ----- */
   const GAME_TIME   = 12;                 // seconds
   const STAIN_START = 15;                 // initial stains
-  const STAIN_SIZE  = 90;                 // px
+  const IS_MOBILE   = window.innerWidth <= 414;
+  let   STAIN_SIZE  = IS_MOBILE ? 68 : 90; // px (smaller on phones)
+  const TOP_MARGIN    = IS_MOBILE ? 10 : 50;
+  const BOTTOM_MARGIN = IS_MOBILE ? 30 : 100;
   const FIRE_RATE   = 3000;               // ms per extra stain
+  const DEVICE      = IS_MOBILE ? 'mobile' : 'kiosk';
   const STAIN_IMAGES = [
     'https://www.dublincleaners.com/wp-content/uploads/2025/08/Ketchup.png',
     'https://www.dublincleaners.com/wp-content/uploads/2025/08/Coffee.png',
@@ -157,10 +165,14 @@
     s.src = randomImage();
     s.className = 'stain';
     const rect = gameArea.getBoundingClientRect();
-    if(x===undefined){ x = Math.random()*(rect.width - STAIN_SIZE); }
-    if(y===undefined){ y = Math.random()*(rect.height - STAIN_SIZE - 100) + 50; }
-    s.style.left = x+'px';
-    s.style.top  = y+'px';
+    const spawnW = rect.width  - STAIN_SIZE;
+    const spawnH = rect.height - STAIN_SIZE - TOP_MARGIN - BOTTOM_MARGIN;
+    if(x===undefined){ x = Math.random()*spawnW; }
+    if(y===undefined){ y = Math.random()*spawnH + TOP_MARGIN; }
+    s.style.left   = x+'px';
+    s.style.top    = y+'px';
+    s.style.width  = STAIN_SIZE+'px';
+    s.style.height = STAIN_SIZE+'px';
     s.addEventListener('pointerdown',()=>{
       s.remove();
       remaining--;
@@ -197,7 +209,7 @@
     const mouthX = rect.left + rect.width*0.15 - area.left;
     const mouthY = rect.top  + rect.height*0.15 - area.top;
     const targetX = Math.random()*(area.width - STAIN_SIZE);
-    const targetY = Math.random()*(area.height - STAIN_SIZE - 100) + 50;
+    const targetY = Math.random()*(area.height - STAIN_SIZE - TOP_MARGIN - BOTTOM_MARGIN) + TOP_MARGIN;
     const angle = Math.atan2(targetY - mouthY, targetX - mouthX);
     cannon.style.transform = `rotate(${angle}rad)`;
     const offset = 30;
@@ -252,7 +264,7 @@
       score: total - remaining,
       missed: remaining,
       duration: (Date.now()-startTime)/1000,
-      device:'kiosk',
+      device: DEVICE,
       geo
     };
     if(success){


### PR DESCRIPTION
## Summary
- Scale and reposition cannon on small screens so the Play button stays clear
- Shrink stains and widen spawn area for tougher mobile play
- Log device type to Sheets and refresh docs for mobile/kiosk builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e3ace2b848322acfa43b3dedfd785