### PR TITLE
fix: reuse geolocation on subsequent plays

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,13 +298,17 @@
   }
 
   playBtn.addEventListener('click', () => {
-    updateGeo().then(allowed => {
-      if(allowed){
-        begin();
-      }else{
-        alert('Location access is required to play.');
-      }
-    });
+    if(geo){
+      begin();
+    }else{
+      updateGeo().then(allowed => {
+        if(allowed){
+          begin();
+        }else{
+          alert('Location access is required to play.');
+        }
+      });
+    }
   });
   document.getElementById('restartBtn').addEventListener('click', reset);
 


### PR DESCRIPTION
## Summary
- avoid mobile replay bug by caching geolocation after first play

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e3f600908832299fc8a8df1985ce9