### PR TITLE
Boost initial stain count for harder gameplay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ The **Stain Blaster** mini-game reinforces Dublin Cleaners’ Three Uniques by i
 
 | Core Loop | Tech / Files |
 |-----------|--------------|
-| 1. Attract screen invites touch.<br>2. Fifteen stains appear over a white shirt background.<br>3. Guests tap/slide each stain → it vanishes.<br>4. Clear all within 12 s (including cannon-fired extras) → confetti, prize, QR.<br>5. Lose → friendly “Try again.” | `Code.gs` – GAS backend (log to Sheet).<br>`index.html` – Tailwind front end with responsive tweaks.<br>Sheet tab **StainBlasterLog** stores timestamp, voucher, prize, score, missed, duration, device, geo. |
+| 1. Attract screen invites touch.<br>2. Twenty-three stains appear over a white shirt background.<br>3. Guests tap/slide each stain → it vanishes.<br>4. Clear all within 12 s (including cannon-fired extras) → confetti, prize, QR.<br>5. Lose → friendly “Try again.” | `Code.gs` – GAS backend (log to Sheet).<br>`index.html` – Tailwind front end with responsive tweaks.<br>Sheet tab **StainBlasterLog** stores timestamp, voucher, prize, score, missed, duration, device, geo. |
 
 ## Prize Logic
 Weighted probabilities (60 % → $5, 25 % → $10, 10 % → $20, 4 % → $25, 1 % → $50) run **client-side** for snappy UX; results post to GAS where marketing can monitor redemption frequency and tweak weights.

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 (() => {
   /* ----- Config ----- */
   const GAME_TIME   = 12;                 // seconds
-  const STAIN_START = 15;                 // initial stains
+  const STAIN_START = 23;                 // initial stains (50% more)
   const IS_MOBILE   = window.innerWidth <= 414;
   let   STAIN_SIZE  = IS_MOBILE ? 68 : 90; // px (smaller on phones)
   const TOP_MARGIN    = IS_MOBILE ? 10 : 50;


### PR DESCRIPTION
## Summary
- raise starting stain count by 50% (15 -> 23) so both mobile and kiosk modes start with more stains on screen
- update agent notes to document the higher initial stain count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e422c80188322bd9c7a66491c9c98