### PR TITLE
Ramp difficulty on win streak

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 * Animations use `bubble-in` (scale/bounce fade-in) and `bubble-out` (fade-out after 5 s).
 * Tweak cadence via `BUBBLE_INTERVAL`/`BUBBLE_JITTER` without redeploying by loading config from GAS.
 
+## Dynamic Difficulty
+* Consecutive wins ramp up the challenge.
+* Each streak shrinks stains ~20 %, adds ~15 % more splatters, and speeds the cannon by ~15 %.
+* Losing resets the streak and returns to base difficulty.
+
 ## Prize Odds
 Default odds live in `index.html`. To adjust without a push, expose them via `logGame` response or a `getConfig()` GAS endpoint, then fetch at runtime.
 

--- a/index.html
+++ b/index.html
@@ -60,12 +60,12 @@
   let STAIN_START = BASE_STAIN_START;
   let STAIN_SIZE  = BASE_STAIN_SIZE;
   let FIRE_RATE   = BASE_FIRE_RATE;
-  let playCount   = parseInt(localStorage.getItem('playCount') || '0', 10);
+  let winStreak   = parseInt(localStorage.getItem('winStreak') || '0', 10);
 
   function applyDifficulty(){
-    STAIN_SIZE  = BASE_STAIN_SIZE / Math.pow(1.15, playCount);
-    STAIN_START = Math.round(BASE_STAIN_START * Math.pow(1.1, playCount));
-    FIRE_RATE   = BASE_FIRE_RATE * Math.pow(0.9, playCount);
+    STAIN_SIZE  = BASE_STAIN_SIZE / Math.pow(1.2, winStreak);
+    STAIN_START = Math.round(BASE_STAIN_START * Math.pow(1.15, winStreak));
+    FIRE_RATE   = BASE_FIRE_RATE * Math.pow(0.85, winStreak);
   }
   const STAIN_IMAGES = [
     'https://www.dublincleaners.com/wp-content/uploads/2025/08/Ketchup.png',
@@ -231,7 +231,6 @@
 
   function begin(){
     applyDifficulty();
-    localStorage.setItem('playCount', ++playCount);
     startScreen.classList.add('hidden');
     clearTimeout(bubbleTimer);
     startScreen.querySelectorAll('.bubble').forEach(b=>b.remove());
@@ -296,6 +295,8 @@
     if(typeof google !== 'undefined'){
       google.script.run.withFailureHandler(()=>{}).logGame(JSON.stringify(payload));
     }
+    winStreak = success ? winStreak + 1 : 0;
+    localStorage.setItem('winStreak', winStreak);
   }
 
   function confetti(){


### PR DESCRIPTION
## Summary
- Scale stain size, count, and cannon fire rate using consecutive win streaks
- Reset win streak on loss to return game to base difficulty
- Document streak-based dynamic difficulty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e482f12548322a41e7f8551486e1e