### PR TITLE
feat: remove mobile press requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ QR codes embed a plain-text voucher string (`DCGC-<epochMs>-<value>`), avoiding 
 * Losses display “Thanks for playing! Please come back in 10 minutes to try again.”
 
 ## Mobile Touch Tweaks
-* Phones render smaller stains, scatter them across a wider vertical range, and require a short (~200 ms) press before a stain disappears.
+* Phones render smaller stains, scatter them across a wider vertical range, and disappear with a quick tap.
 
 ## QR Rewards
 * Wins show a QR‑encoded voucher worth $5‑$50.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 * Losses immediately show “Thanks for playing! Please come back in 10 minutes to try again.”
 
 ## Mobile Optimizations
-* Phones render smaller stains, spread them across a wider vertical range, and require a brief (~200 ms) press before a stain clears.
+* Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.
 
 ## QR Rewards
 * Victories produce a QR‑encoded voucher worth $5‑$50.

--- a/index.html
+++ b/index.html
@@ -213,11 +213,7 @@
       if(remaining===0 && seconds>0) win();
     };
     if(IS_MOBILE){
-      let hold;
-      s.addEventListener('touchstart', () => {
-        hold = setTimeout(remove, 200); // longer hold on mobile
-      }, {passive:true});
-      s.addEventListener('touchend', () => clearTimeout(hold));
+      s.addEventListener('touchstart', remove, {passive:true});
     }else{
       s.addEventListener('pointerdown', remove);
     }


### PR DESCRIPTION
## Summary
- allow mobile stains to clear on tap instead of requiring a 200ms press
- update mobile play documentation to reflect tap-to-clear behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e4e3b7c448322b85c408f2ee78265