### PR TITLE
feat: rotate loser tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 ## QR Rewards
 * Victories produce a QR‑encoded voucher worth $5‑$50.
 * Even losses present a QR with a short cleaning tip to reinforce eco expertise.
+* Tips rotate from the `LOSS_TIPS` array; edit it to add or tweak loser messages like “Misleading Label” or “Mysterious Lint Monster.”
 
 ## Prize Odds
 Default odds live in `index.html`. To adjust without a push, expose them via `logGame` response or a `getConfig()` GAS endpoint, then fetch at runtime.

--- a/index.html
+++ b/index.html
@@ -98,6 +98,12 @@
   const BUBBLE_INTERVAL = 4000; // ms between spawns
   const BUBBLE_JITTER   = 1000; // ms random jitter
   const BUBBLE_DURATION = 5000; // ms visible
+  const LOSS_TIPS = [
+    {label:'Misleading Label Loser', tip:'TIP: Test a hidden seam—when in doubt, obey the tag.'},
+    {label:'Wrinkle Waster Loser', tip:'TIP: Hang shirts in the shower—steam irons for free.'},
+    {label:'Late to Laundry Loser', tip:'TIP: Set an app reminder; our van won’t guess.'},
+    {label:'Mysterious Lint Monster Loser', tip:'TIP: Empty the lint tray—your dryer isn’t a Hoover.'}
+  ];
 
   /* ----- DOM refs ----- */
   const startScreen = document.getElementById('startScreen');
@@ -350,8 +356,10 @@
       handleGameEnd('win');
       resultText.innerHTML = `Congrats! You won a $${prize} gift certificate 🎉<br>` + resultText.innerHTML;
     }else{
-      new QRCode(qrWrap,{text:"TIP: Blot, don't rub!",width:256,height:256});
+      const pick = LOSS_TIPS[Math.floor(Math.random()*LOSS_TIPS.length)];
       handleGameEnd('lose');
+      resultText.innerHTML = `${pick.label}<br>${resultText.innerHTML}`;
+      new QRCode(qrWrap,{text:pick.tip,width:256,height:256});
     }
     if(typeof google !== 'undefined'){
       google.script.run.withFailureHandler(()=>{}).logGame(JSON.stringify(payload));


### PR DESCRIPTION
## Summary
- add LOSS_TIPS array with branded laundry advice for common "losers"
- display a random loser label and QR code tip on defeat
- document how to edit loser tips in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e50d69bfc8322abef46408f41a978