### PR TITLE
Remove cooldown timer to allow immediate replays

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 * Each streak shrinks stains ~20 %, adds ~15 % more splatters, and speeds the cannon by ~15 %.
 * Losing resets the streak and returns to base difficulty.
 
-## Fair Play Lock & Bonus Rounds
-* LocalStorage enforces a 10‑minute cooldown between plays on the same device.
-* Winners flip a virtual coin for an instant bonus round; if not selected they must wait 15 minutes.
-* Losses immediately show “Thanks for playing! Please come back in 10 minutes to try again.”
+## Replay Policy
+* Players can start a new round immediately after each game.
+* Consecutive wins continue to ramp difficulty to keep the challenge lively.
 
 ## Mobile Optimizations
 * Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.

--- a/index.html
+++ b/index.html
@@ -125,42 +125,12 @@
     }
   }
 
-  function getSession(){
-    return JSON.parse(localStorage.getItem('gameSession')) || {};
-  }
-
-  function saveSession(s){
-    localStorage.setItem('gameSession', JSON.stringify(s));
-  }
-
-  function canPlayNow(){
-    const now = Date.now();
-    const session = getSession();
-    return !session.eligibleAt || now >= session.eligibleAt;
-  }
-
   function handleGameEnd(result){
-    const now = Date.now();
-    let session = getSession();
-    session.lastPlay = now;
-
     if(result === 'lose'){
-      session.winCount = 0;
-      session.eligibleAt = now + 10 * 60 * 1000;
-      showMessage("Thanks for playing! Please come back in 10 minutes to try again.");
+      showMessage("Thanks for playing! Tap Play Again to try once more.");
     } else if(result === 'win'){
-      const bonusChance = session.winCount === 0 ? 0.5 : 0.3;
-      const gotBonus = Math.random() < bonusChance;
-      if(gotBonus){
-        session.winCount = (session.winCount || 0) + 1;
-        showMessage("Lucky you! You’ve earned a bonus round. Tap to play again!");
-      } else {
-        session.winCount = 0;
-        session.eligibleAt = now + 10 * 60 * 1000;
-        showMessage("Great job! You’ve won. Come back in 10 minutes for another chance!");
-      }
+      showMessage("Great job! Tap Play Again for another round!");
     }
-    saveSession(session);
   }
 
   function updateGeo(){
@@ -381,27 +351,19 @@
   }
 
   playBtn.addEventListener('click', () => {
-    if(!canPlayNow()){
-      showMessage("Please come back in 10 minutes to try again.");
-      return;
-    }
     if(geo){
       begin();
-    }else{
+    } else {
       updateGeo().then(allowed => {
         if(allowed){
           begin();
-        }else{
+        } else {
           alert('Location access is required to play.');
         }
       });
     }
   });
   document.getElementById('restartBtn').addEventListener('click', () => {
-    if(!canPlayNow()){
-      showMessage("Please come back in 10 minutes to try again.");
-      return;
-    }
     resultScreen.classList.add('hidden');
     begin();
   });


### PR DESCRIPTION
## Summary
- remove 10-minute cooldown and bonus logic so players can replay instantly
- update replay policy documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e56436e488322835ff3bfed5aedff