### PR TITLE
Reset win streak after inactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 * Consecutive wins ramp up the challenge.
 * Each streak shrinks stains ~20 %, adds ~15 % more splatters, and speeds the cannon by ~15 %.
 * Losing resets the streak and returns to base difficulty.
+* Streak resets after 5 minutes of inactivity on the same device.
 
 ## Replay Policy
 * Players can start a new round immediately after each game.

--- a/index.html
+++ b/index.html
@@ -57,10 +57,17 @@
   const TOP_MARGIN    = IS_MOBILE ? 10 : 50;
   const BOTTOM_MARGIN = IS_MOBILE ? 30 : 100;
   const DEVICE      = IS_MOBILE ? 'mobile' : 'kiosk';
+  const STREAK_WINDOW = 5 * 60 * 1000;    // 5 minutes
   let STAIN_START = BASE_STAIN_START;
   let STAIN_SIZE  = BASE_STAIN_SIZE;
   let FIRE_RATE   = BASE_FIRE_RATE;
   let winStreak   = parseInt(localStorage.getItem('winStreak') || '0', 10);
+  let streakTime  = parseInt(localStorage.getItem('winStreakTime') || '0', 10);
+  if(!streakTime || Date.now() - streakTime > STREAK_WINDOW){
+    winStreak = 0;
+    localStorage.setItem('winStreak', '0');
+    localStorage.setItem('winStreakTime', Date.now().toString());
+  }
   let timeOffset  = 0;                        // server vs client clock diff
 
   if(typeof google !== 'undefined'){
@@ -336,6 +343,7 @@
     }
     winStreak = success ? winStreak + 1 : 0;
     localStorage.setItem('winStreak', winStreak);
+    localStorage.setItem('winStreakTime', Date.now().toString());
   }
 
   function confetti(){


### PR DESCRIPTION
## Summary
- reset win streak if more than 5 minutes pass on a device
- record timestamp when streak changes to enforce cooldown
- document streak reset window in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5751328883228a9b08195eed6d8a