### PR TITLE
Remove cooldown message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@ Weighted probabilities (60 % → $5, 25 % → $10, 10 % → $20, 4 % → $25, 1 
 QR codes embed a plain-text voucher string (`DCGC-<epochMs>-<value>`), avoiding URL requirements yet uniquely identifying each win.
 
 ## Fair Play & Bonus Rounds
-* LocalStorage tracks `nextPlay` so each device can run the game only once every 10 minutes.
-* Winners get a 50 % coin‑flip for an instant bonus round; otherwise a 15 minute cooldown with a friendly heads‑up.
-* Losses display “Thanks for playing! Please come back in 10 minutes to try again.”
+* Players can start a new round immediately; no cooldown or `nextPlay` tracking.
+* Winners get a 50 % coin‑flip for an instant bonus round.
+* Losses display "Thanks for playing! Tap Play Again to try again."
 
 ## Mobile Touch Tweaks
 * Phones render smaller stains, scatter them across a wider vertical range, and disappear with a quick tap.

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
 
   function handleGameEnd(result){
     if(result === 'lose'){
-      showMessage("Please come back in 10 minutes to try again.");
+      showMessage("Thanks for playing! Tap Play Again to try again.");
     } else if(result === 'win'){
       showMessage("Great job! Tap Play Again for another round!");
     }


### PR DESCRIPTION
## Summary
- Remove outdated 10-minute cooldown prompt and allow immediate replay.
- Update agent notes to reflect instant replays and new loss message.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5def09d483229d6bb2916aea1800