### PR TITLE
Improve first-play responsiveness and tidy win screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,8 @@
     resultScreen.classList.remove('hidden');
     qrWrap.innerHTML = '';
     qrWrap.className = 'p-4 bg-stone-100 rounded-2xl shadow-inner';
+    // Clear any previous result text so only the final message is shown
+    resultText.textContent = '';
     const payload = {
       prize:0, code:'',
       score: total - remaining,
@@ -395,6 +397,8 @@
   });
 
   scheduleBubble();
+  // Pre-fetch geolocation so the Play button responds immediately on first tap
+  updateGeo();
 
   setInterval(()=>{
     if(!resultScreen.classList.contains('hidden') &&


### PR DESCRIPTION
## Summary
- Prefetch geolocation on load so the Play button reacts immediately on first tap
- Clear old result text when showing the win screen to avoid a duplicate message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8ce090bc8322a56299dc67c5d7c5