### PR TITLE
feat: add tiered reward distribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,14 @@ The **Stain Blaster** mini-game reinforces Dublin Cleaners’ Three Uniques by i
 | 1. Attract screen invites touch.<br>2. Twenty-three stains appear over a white shirt background.<br>3. Guests tap/slide each stain → it vanishes.<br>4. Clear all within 12 s (including cannon-fired extras) → confetti, prize, QR.<br>5. Lose → friendly “Try again.” | `Code.gs` – GAS backend (log to Sheet).<br>`index.html` – Tailwind front end with responsive tweaks.<br>Sheet tab **StainBlasterLog** stores timestamp, voucher, prize, score, missed, duration, device, geo. |
 
 ## Prize Logic
-Weighted probabilities (60 % → $5, 25 % → $10, 10 % → $20, 4 % → $25, 1 % → $50) run **client-side** for snappy UX; results post to GAS where marketing can monitor redemption frequency and tweak weights.
+Tiered rewards run **client-side** for snappy UX; results post to GAS where marketing can monitor redemption frequency and tweak weights.
+
+| Tier | Chance | Reward | Notes |
+|------|--------|--------|-------|
+| 1 – Common | 60 % | Eco tip / share-GIF | No monetary value |
+| 2 – Uncommon | 25 % | $5 cleaning credit or free button replacement | Credit = store gift code |
+| 3 – Rare | 12 % | $10 cleaning credit or comped shirt press | ≤ 5 redemptions/day |
+| 4 – Epic | 3 % | Comped premium garment (e.g., gown clean) or VIP rush credit | 1/day cap, manager approval |
 
 ## QR Content
 QR codes embed a plain-text voucher string (`DCGC-<epochMs>-<value>`), avoiding URL requirements yet uniquely identifying each win.
@@ -22,7 +29,7 @@ QR codes embed a plain-text voucher string (`DCGC-<epochMs>-<value>`), avoiding 
 * Phones render smaller stains, scatter them across a wider vertical range, and disappear with a quick tap.
 
 ## QR Rewards
-* Wins show a QR‑encoded voucher worth $5‑$50.
+* Wins yield tiered rewards from eco tips to premium garment comps.
 * Losses still present a QR with a quick cleaning tip to reinforce eco expertise.
 
 ## Offline Resilience

--- a/README.md
+++ b/README.md
@@ -36,12 +36,20 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
 * Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.
 
 ## QR Rewards
-* Victories produce a QR‑encoded voucher worth $5‑$50.
+* Victories yield tiered rewards, from eco tips to premium garment comps.
 * Even losses present a QR with a short cleaning tip to reinforce eco expertise.
 * Tips rotate from the `LOSS_TIPS` array; edit it to add or tweak loser messages like “Misleading Label” or “Mysterious Lint Monster.”
 
 ## Prize Odds
 Default odds live in `index.html`. To adjust without a push, expose them via `logGame` response or a `getConfig()` GAS endpoint, then fetch at runtime.
+
+### Tiered Rewards (per round)
+| Tier | Chance | Reward | Notes |
+|------|--------|--------|-------|
+| Common | 60% | Eco tip or share-GIF | No monetary value |
+| Uncommon | 25% | $5 cleaning credit or free button replacement | Credit = store gift code |
+| Rare | 12% | $10 cleaning credit or comped shirt press | ≤ 5 redemptions/day |
+| Epic | 3% | Comped premium garment (e.g., gown clean) or VIP rush credit | 1/day cap, manager approval |
 
 ### Ladder Bonuses
 Consecutive wins unlock a bonus ladder with its own probabilities:

--- a/index.html
+++ b/index.html
@@ -87,15 +87,14 @@
     'https://www.dublincleaners.com/wp-content/uploads/2025/08/Wine.png'
   ];
   const PRIZES      = [                   // cumulative probability table
-    {p:0.60, value:5},
-    {p:0.85, value:10},
-    {p:0.95, value:20},
-    {p:0.99, value:25},
-    {p:1.00, value:50}
+    {p:0.60, type:'tip',     value:0,  desc:'Eco tip / share-GIF'},
+    {p:0.85, type:'credit',  value:5,  desc:'$5 cleaning credit or free button replacement'},
+    {p:0.97, type:'credit',  value:10, desc:'$10 cleaning credit or comped shirt press'},
+    {p:1.00, type:'premium', value:0,  desc:'Comped premium garment or VIP rush credit'}
   ];
   const BUBBLE_LINES = [
     'Think you can wipe all the stains?',
-    'Win up to $50 in 12 seconds!',
+    'Eco tips to premium perks await!',
     'Swipe fast – prizes await!',
     'Spotless skills? Prove it!',
     'Tap ▶ to blast and earn!',
@@ -148,7 +147,7 @@
 
   function pickPrize(){
     const r = Math.random();
-    return PRIZES.find(t => r <= t.p).value;
+    return PRIZES.find(t => r <= t.p);
   }
 
   function randomImage(){
@@ -326,20 +325,39 @@
     };
     if(success){
       const handle = res => {
-        let prize;
+        let prizeObj;
         if(res && res.success){
-          prize = res.prize;
+          prizeObj = {value:res.prize, type:'credit'};
         }else{
-          prize = pickPrize();
+          prizeObj = pickPrize();
         }
-        const code  = `DCGC-${Date.now()}-${prize}`;
-        new QRCode(qrWrap,{text:encodeForQR(code),width:256,height:256});
-        confetti();
-        payload.prize = prize;
-        payload.code  = code;
         payload.missed = 0;
         payload.score = total;
-        resultText.textContent = `Congrats! You won a $${prize} gift certificate 🎉`;
+        if(prizeObj.value > 0){
+          const code  = `DCGC-${Date.now()}-${prizeObj.value}`;
+          new QRCode(qrWrap,{text:encodeForQR(code),width:256,height:256});
+          confetti();
+          payload.prize = prizeObj.value;
+          payload.code  = code;
+          resultText.textContent = `Congrats! You won a $${prizeObj.value} cleaning credit 🎉`;
+        }else if(prizeObj.type === 'tip'){
+          confetti();
+          const tip = cleaningTips[Math.floor(Math.random()*cleaningTips.length)];
+          resultText.textContent = 'Eco Bonus! Enjoy this cleaning tip 🌱';
+          qrWrap.className = 'p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg';
+          const tipDiv = document.createElement('div');
+          tipDiv.className = 'text-xl text-stone-700 whitespace-pre-line';
+          tipDiv.innerHTML = tip;
+          qrWrap.appendChild(tipDiv);
+        }else{
+          confetti();
+          resultText.textContent = 'Epic win! Show this screen for a premium garment clean or VIP rush credit 🎉';
+          qrWrap.className = 'p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg text-center';
+          const msgDiv = document.createElement('div');
+          msgDiv.className = 'text-xl text-stone-700';
+          msgDiv.textContent = 'Present to staff for manual redemption.';
+          qrWrap.appendChild(msgDiv);
+        }
         if(typeof google !== 'undefined'){
           google.script.run.withFailureHandler(()=>{}).logGame(JSON.stringify(payload));
         }


### PR DESCRIPTION
## Summary
- add four-tier reward probabilities with client-side handling for tips, credits, and premium comps
- document tiered rewards in README and developer notes
- refresh attract-screen copy to highlight new perk structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892a38663dc832287ee514673992fe7