### PR TITLE
chore: enforce iframe permissions policy

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -18,8 +18,7 @@ const HEADERS = [
   'Stains cleared',
   'Stains missed',
   'Seconds taken',
-  'Device',            // 'kiosk' or 'mobile'
-  'Geo location'
+  'Device'            // 'kiosk' or 'mobile'
 ];
 
 /** Serve the kiosk page */
@@ -27,7 +26,9 @@ function doGet() {
   return HtmlService.createHtmlOutputFromFile('index')
     .setTitle('Stain Blaster – Dublin Cleaners')
     .addMetaTag('viewport', 'width=device-width, initial-scale=1')
-    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+    .addMetaTag('permissions-policy', 'autoplay=(self)')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+    .setSandboxMode(HtmlService.SandboxMode.IFRAME);
 }
 
 /** Append one row of JSON-encoded data from client */
@@ -52,8 +53,7 @@ function logGame(dataJSON) {
     d.score,               // Stains cleared
     d.missed || 0,         // Stains missed
     d.duration,            // Seconds taken
-    d.device || 'kiosk',   // Device label
-    d.geo || ''            // Geo location
+    d.device || 'kiosk'    // Device label
   ]);
   return true;
 }

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait ki
    ```html
    <iframe
      src="YOUR_DEPLOYED_URL/exec"
-     width="100%" height="800" style="border:0;">
-   </iframe>
+     width="100%" height="100%"
+     style="border:0;"
+     allow="autoplay; fullscreen"
+     allowfullscreen
+   ></iframe>
    ```
 
 ## Attract Bubbles

--- a/index.html
+++ b/index.html
@@ -127,23 +127,7 @@
   const logo        = document.getElementById('logo');
   const playBtn     = document.getElementById('playBtn');
   let remaining, total, seconds, countdown, startTime, fireInterval, bubbleTimer,
-      geo = '', resultShown = false;
-
-  function updateGeo(){
-    return new Promise(resolve => {
-      if(navigator.geolocation){
-        navigator.geolocation.getCurrentPosition(pos => {
-          geo = `${pos.coords.latitude},${pos.coords.longitude}`;
-          resolve(true);
-        }, () => {
-          geo = '';
-          resolve(false);
-        });
-      } else {
-        resolve(false);
-      }
-    });
-  }
+      resultShown = false;
 
   function pickPrize(){
     const r = Math.random();
@@ -320,8 +304,7 @@
       score: total - remaining,
       missed: remaining,
       duration: (now()-startTime)/1000,
-      device: DEVICE,
-      geo
+      device: DEVICE
     };
     if(success){
       const handle = res => {
@@ -397,17 +380,7 @@
   }
 
   playBtn.addEventListener('click', () => {
-    if(geo){
-      startRound();
-    } else {
-      updateGeo().then(allowed => {
-        if(allowed){
-          startRound();
-        } else {
-          alert('Location access is required to play.');
-        }
-      });
-    }
+    startRound();
   });
   document.getElementById('restartBtn').addEventListener('click', () => {
     resultScreen.classList.add('hidden');
@@ -415,8 +388,6 @@
   });
 
   scheduleBubble();
-  // Pre-fetch geolocation so the Play button responds immediately on first tap
-  updateGeo();
 
   setInterval(()=>{
     if(!resultScreen.classList.contains('hidden') &&


### PR DESCRIPTION
## Summary
- whitelist autoplay and fullscreen in README embed snippet
- remove geolocation access and unused logging from game code
- add permissions-policy meta tag and sandbox mode in Apps Script output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e8ba8d408322b65b5d583bfa5173