### PR TITLE
fix: remove unsupported permissions-policy meta tag

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -26,7 +26,6 @@ function doGet() {
   return HtmlService.createHtmlOutputFromFile('index')
     .setTitle('Stain Blaster – Dublin Cleaners')
     .addMetaTag('viewport', 'width=device-width, initial-scale=1')
-    .addMetaTag('permissions-policy', 'autoplay=(self)')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
     .setSandboxMode(HtmlService.SandboxMode.IFRAME);
 }


### PR DESCRIPTION
## Summary
- remove disallowed `permissions-policy` meta tag from Apps Script HTML output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893eb8d00908322be153b912d6bbd6d