### PR TITLE
Remove monetary prizes, keep cleaning tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stain Blaster Kiosk Game
 
-An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to win instant, QR‑encoded gift certificates. The same build now scales down for phones, keeping the cannon visible and shrinking stains for added challenge.
+An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to reveal a quick cleaning tip. The same build now scales down for phones, keeping the cannon visible and shrinking stains for added challenge.
 
 ## Kiosk/Iframe Build
 
@@ -22,8 +22,8 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 * **Google Apps Script (HTML Service)** – one `Code.gs` backend.
 * **Tailwind CSS via CDN** – rapid, utility-first styling.
 * **Vanilla JS** – fast, dependency-light touch handling.
-* **qrcodejs** & **canvas-confetti** CDNs – QR & celebration effects.
-* **Google Sheets** – prize logging for marketing analytics.
+* **canvas-confetti** CDN – celebration effects.
+* **Google Sheets** – game logging for analytics.
 
 ## Quick Start
 1. The provided `Code.gs` logs to [this Google Sheet](https://docs.google.com/spreadsheets/d/17k6TfJeAERydKa0L0vAXRp6y0q3zckB35dFv9qfDQ6g/edit) by default.
@@ -51,33 +51,8 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 ## Mobile Optimizations
 * Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.
 
-## QR Rewards
-* Victories yield tiered rewards, from eco tips to premium garment comps.
-* Even losses present a QR with a short cleaning tip to reinforce eco expertise.
-* Tips rotate from the `LOSS_TIPS` array; edit it to add or tweak loser messages like “Misleading Label” or “Mysterious Lint Monster.”
-
-## Prize Odds
-Default odds live in `index.html`. To adjust without a push, expose them via `logGame` response or a `getConfig()` GAS endpoint, then fetch at runtime.
-
-### Tiered Rewards (per round)
-| Tier | Chance | Reward | Notes |
-|------|--------|--------|-------|
-| Common | 60% | Eco tip or share-GIF | No monetary value |
-| Uncommon | 25% | $5 cleaning credit or free button replacement | Credit = store gift code |
-| Rare | 12% | $10 cleaning credit or comped shirt press | ≤ 5 redemptions/day |
-| Epic | 3% | Comped premium garment (e.g., gown clean) or VIP rush credit | 1/day cap, manager approval |
-
-### Ladder Bonuses
-Consecutive wins unlock a bonus ladder with its own probabilities:
-
-| winStreak | Bonus Credit | Chance |
-|-----------|--------------|-------|
-| 0         | $5           | 50 %  |
-| 1         | $10          | 25 %  |
-| 2         | $25          | 25 %  |
-| 3         | $50          | 10 %  |
-
-Failing a ladder roll still awards a normal prize and resets the streak.
+## Cleaning Tips
+* Every round ends with a rotating eco-friendly cleaning tip to reinforce garment care.
 
 ## Sheet Schema
 Each play logs a row to the Google Sheet with the following columns:
@@ -85,14 +60,12 @@ Each play logs a row to the Google Sheet with the following columns:
 | Column | Header         | Purpose                                 |
 | ------ | -------------- | --------------------------------------- |
 | A      | Timestamp      | When the result was recorded            |
-| B      | Voucher code   | Unique voucher string (blank on loss)   |
-| C      | Prize $        | Dollar value awarded to the player      |
-| D      | Stains cleared | Number of stains the player removed     |
-| E      | Stains missed  | Stains left when time expired           |
-| F      | Seconds taken  | Duration of the game in seconds         |
-| G      | Device         | Source device label (kiosk or mobile)   |
+| B      | Stains cleared | Number of stains the player removed     |
+| C      | Stains missed  | Stains left when time expired           |
+| D      | Seconds taken  | Duration of the game in seconds         |
+| E      | Device         | Source device label (kiosk or mobile)   |
 
-Monitor play counts, difficulty, and cost; pivot by day for prize budgeting.
+Monitor play counts and difficulty; pivot by day for analytics.
 
 ## Local Assets
 * **Shirt background** – 1080 × 1920 PNG of a pressed white dress shirt.
@@ -106,4 +79,3 @@ Internal use only – Dublin Cleaners. Fork freely inside org.
 ## v2 Addendum
 * Rounds locked to 12 seconds.
 * Difficulty scales exponentially each level via stain count/size/spawn interval curve.
-* Rewards are whole-dollar credits or comped garments – never percentage discounts to protect pricing.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Stain Blaster – Dublin Cleaners</title>
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <style>
     .stain{position:absolute;filter:drop-shadow(2px 2px 3px rgba(0,0,0,0.4));z-index:10;}
@@ -27,7 +26,7 @@
   <div id="startScreen" class="absolute inset-0 flex flex-col items-center justify-center gap-8 bg-white touch-none select-none">
     <img id="logo" src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png" alt="Dublin Cleaners" class="w-56">
     <div class="text-5xl font-bold text-stone-700 text-center leading-tight">Stain Blaster</div>
-    <div class="text-xl text-stone-500 text-center">Swipe the stains away in 12 seconds<br>and win an instant reward!</div>
+    <div class="text-xl text-stone-500 text-center">Swipe the stains away in 12 seconds<br>and reveal a cleaning tip!</div>
     <button id="playBtn" class="px-6 py-3 bg-emerald-600 text-white text-2xl rounded-2xl shadow-lg active:scale-95 transition">Play Now</button>
   </div>
 
@@ -71,11 +70,6 @@
 
   function now(){ return Date.now() + timeOffset; }
 
-  // Encode strings so QRCode library handles Unicode characters correctly
-  function encodeForQR(str){
-    return unescape(encodeURIComponent(str));
-  }
-
   function applyDifficulty(){
     STAIN_SIZE  = BASE_STAIN_SIZE / Math.pow(1.2, winStreak);
     STAIN_START = Math.round(BASE_STAIN_START * Math.pow(1.15, winStreak));
@@ -87,18 +81,12 @@
     'https://www.dublincleaners.com/wp-content/uploads/2025/08/Dirt.png',
     'https://www.dublincleaners.com/wp-content/uploads/2025/08/Wine.png'
   ];
-  const PRIZES      = [                   // cumulative probability table
-    {p:0.60, type:'tip',     value:0,  desc:'Eco tip / share-GIF'},
-    {p:0.85, type:'credit',  value:5,  desc:'$5 cleaning credit or free button replacement'},
-    {p:0.97, type:'credit',  value:10, desc:'$10 cleaning credit or comped shirt press'},
-    {p:1.00, type:'premium', value:0,  desc:'Comped premium garment or VIP rush credit'}
-  ];
   const BUBBLE_LINES = [
     'Think you can wipe all the stains?',
-    'Eco tips to premium perks await!',
-    'Swipe fast – prizes await!',
+    'Eco cleaning tips await!',
+    'Swipe fast – tips await!',
     'Spotless skills? Prove it!',
-    'Tap ▶ to blast and earn!',
+    'Tap ▶ to blast and learn!',
     'Your dry-cleaner believes in you 😎'
   ];
   const BUBBLE_INTERVAL = 4000; // ms between spawns
@@ -129,11 +117,6 @@
   const playBtn     = document.getElementById('playBtn');
   let remaining, total, seconds, countdown, startTime, fireInterval, bubbleTimer,
       resultShown = false;
-
-  function pickPrize(){
-    const r = Math.random();
-    return PRIZES.find(t => r <= t.p);
-  }
 
   function randomImage(){
     return STAIN_IMAGES[Math.floor(Math.random()*STAIN_IMAGES.length)];
@@ -298,62 +281,31 @@
     resultScreen.classList.remove('hidden');
     qrWrap.innerHTML = '';
     qrWrap.className = 'p-4 bg-stone-100 rounded-2xl shadow-inner';
-    // Clear any previous result text so only the final message is shown
     resultText.textContent = '';
     const payload = {
-      prize:0, code:'',
       score: total - remaining,
       missed: remaining,
       duration: (now()-startTime)/1000,
       device: DEVICE
     };
+    const tip = cleaningTips[Math.floor(Math.random()*cleaningTips.length)];
     if(success){
-      const handle = res => {
-        let prizeObj;
-        if(res && res.success){
-          prizeObj = {value:res.prize, type:'credit'};
-        }else{
-          prizeObj = pickPrize();
-        }
-        payload.missed = 0;
-        payload.score = total;
-        if(prizeObj.value > 0){
-          const code  = `DCGC-${Date.now()}-${prizeObj.value}`;
-          new QRCode(qrWrap,{text:encodeForQR(code),width:256,height:256});
-          confetti();
-          payload.prize = prizeObj.value;
-          payload.code  = code;
-          resultText.textContent = `Congrats! You won a $${prizeObj.value} cleaning credit 🎉`;
-        }else if(prizeObj.type === 'tip'){
-          confetti();
-          const tip = cleaningTips[Math.floor(Math.random()*cleaningTips.length)];
-          resultText.textContent = 'Eco Bonus! Enjoy this cleaning tip 🌱';
-          qrWrap.className = 'p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg';
-          const tipDiv = document.createElement('div');
-          tipDiv.className = 'text-xl text-stone-700 whitespace-pre-line';
-          tipDiv.innerHTML = tip;
-          qrWrap.appendChild(tipDiv);
-        }else{
-          confetti();
-          resultText.textContent = 'Epic win! Show this screen for a premium garment clean or VIP rush credit 🎉';
-          qrWrap.className = 'p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg text-center';
-          const msgDiv = document.createElement('div');
-          msgDiv.className = 'text-xl text-stone-700';
-          msgDiv.textContent = 'Present to staff for manual redemption.';
-          qrWrap.appendChild(msgDiv);
-        }
-        if(typeof google !== 'undefined'){
-          google.script.run.withFailureHandler(()=>{}).logGame(JSON.stringify(payload));
-        }
-        winStreak = res ? res.winStreak : 0;
-      };
+      payload.missed = 0;
+      payload.score = total;
+      resultText.textContent = 'Great job! Enjoy this cleaning tip 🌱';
+      qrWrap.className = 'p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg';
+      const tipDiv = document.createElement('div');
+      tipDiv.className = 'text-xl text-stone-700 whitespace-pre-line';
+      tipDiv.innerHTML = tip;
+      qrWrap.appendChild(tipDiv);
+      confetti();
       if(typeof google !== 'undefined'){
-        google.script.run.withSuccessHandler(handle).handleWin();
+        google.script.run.withFailureHandler(()=>{}).logGame(JSON.stringify(payload));
+        google.script.run.withSuccessHandler(r=>{winStreak=r.winStreak;}).handleWin();
       }else{
-        handle({success:false, winStreak:0});
+        winStreak = 0;
       }
     }else{
-      const tip = cleaningTips[Math.floor(Math.random()*cleaningTips.length)];
       resultText.textContent = 'Thanks for playing! Tap Play Again to try again.';
       qrWrap.className = 'p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg';
       const tipDiv = document.createElement('div');


### PR DESCRIPTION
## Summary
- Drop QR code and prize logic; wins now just show a random cleaning tip
- Simplify backend logging and win-streak handling without prize amounts
- Refresh documentation to reflect tip-only rewards

## Testing
- `npm test`
- `npm run lint` (no matching files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b30019b1e883229151a8a984554e5b