### PR TITLE
Implement prize tiers with unique credit codes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -16,7 +16,9 @@ const HEADERS = [
   'Stains cleared',
   'Stains missed',
   'Seconds taken',
-  'Device'            // 'kiosk' or 'mobile'
+  'Device',           // 'kiosk' or 'mobile'
+  'Prize Tier',
+  'Prize Code'
 ];
 
 /** Serve the kiosk page */
@@ -46,7 +48,9 @@ function logGame(dataJSON) {
     d.score,               // Stains cleared
     d.missed || 0,         // Stains missed
     d.duration,            // Seconds taken
-    d.device || 'kiosk'    // Device label
+    d.device || 'kiosk',   // Device label
+    d.prizeTier || '',     // Prize tier name
+    d.prizeCode || ''      // Unique prize code if applicable
   ]);
   return true;
 }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 ## Cleaning Tips
 * Every round ends with a rotating eco-friendly cleaning tip to reinforce garment care.
 
+## Prize Tiers
+
+| Tier      | Probability | Reward                                  | Notes                                                                 |
+| --------- | ----------- | --------------------------------------- | --------------------------------------------------------------------- |
+| Common    | 60%         | Cleaning Tip                            | No monetary value                                                     |
+| Uncommon  | 25%         | $5 cleaning credit                      | Take a Photo of Credit & Show to CSR for Credit                       |
+| Rare      | 12%         | $10 cleaning credit (Level 2+)          | Take a Photo of Credit & Show to CSR for Credit                       |
+| Epic      | 3%          | $50 premium garment credit (Level 3+)   | 1/day cap, manager approval. Take a Photo of Credit & Show to CSR     |
+
 ## Sheet Schema
 Each play logs a row to the Google Sheet with the following columns:
 
@@ -64,6 +73,8 @@ Each play logs a row to the Google Sheet with the following columns:
 | C      | Stains missed  | Stains left when time expired           |
 | D      | Seconds taken  | Duration of the game in seconds         |
 | E      | Device         | Source device label (kiosk or mobile)   |
+| F      | Prize Tier     | Awarded tier (Common/Uncommon/Rare/Epic) |
+| G      | Prize Code     | Unique code for credit prizes           |
 
 Monitor play counts and difficulty; pivot by day for analytics.
 

--- a/index.html
+++ b/index.html
@@ -223,6 +223,44 @@
             TIP_DISCLAIMER,
         ];
 
+        const PRIZES = [
+          { tier: "Common", probability: 0.6, reward: null, minLevel: 1 },
+          {
+            tier: "Uncommon",
+            probability: 0.25,
+            reward: "$5 cleaning credit",
+            minLevel: 1,
+          },
+          {
+            tier: "Rare",
+            probability: 0.12,
+            reward: "$10 cleaning credit",
+            minLevel: 2,
+          },
+          {
+            tier: "Epic",
+            probability: 0.03,
+            reward: "$50 premium garment credit",
+            minLevel: 3,
+          },
+        ];
+
+        function pickPrize(level) {
+          const r = Math.random();
+          let sum = 0;
+          for (const p of PRIZES) {
+            sum += p.probability;
+            if (r < sum) {
+              return level >= p.minLevel ? p : PRIZES[0];
+            }
+          }
+          return PRIZES[0];
+        }
+
+        function genCode() {
+          return `DC-${Date.now().toString(36).toUpperCase()}`;
+        }
+
         /* ----- DOM refs ----- */
         const startScreen = document.getElementById("startScreen");
         const gameArea = document.getElementById("gameArea");
@@ -448,9 +486,39 @@
           if (success) {
             payload.missed = 0;
             payload.score = total;
-            resultText.textContent = "Great job! Enjoy this cleaning tip 🌱";
+            const level = winStreak + 1;
+            const prize = pickPrize(level);
+            payload.prizeTier = prize.tier;
+            let code = "";
+            if (prize.tier === "Common") {
+              resultText.textContent = "Great job! Enjoy this cleaning tip 🌱";
+            } else {
+              resultText.textContent = `Great job! You won ${prize.reward}!`;
+            }
             qrWrap.className =
               "p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg";
+            if (prize.tier !== "Common") {
+              const prizeEl = document.createElement("div");
+              prizeEl.className = "text-2xl text-emerald-700 font-bold text-center";
+              prizeEl.textContent = prize.reward;
+              qrWrap.appendChild(prizeEl);
+              const noteEl = document.createElement("div");
+              noteEl.className = "text-sm text-stone-600 text-center";
+              noteEl.textContent = "Take a Photo of Credit & Show to CSR for Credit";
+              qrWrap.appendChild(noteEl);
+              if (prize.tier === "Epic") {
+                const capEl = document.createElement("div");
+                capEl.className = "text-xs text-stone-500 text-center";
+                capEl.textContent = "1/day cap, manager approval";
+                qrWrap.appendChild(capEl);
+              }
+              code = genCode();
+              payload.prizeCode = code;
+              const codeEl = document.createElement("div");
+              codeEl.className = "font-mono text-lg text-center";
+              codeEl.textContent = `Code: ${code}`;
+              qrWrap.appendChild(codeEl);
+            }
             const tipDiv = document.createElement("div");
             tipDiv.className = "text-xl text-stone-700 whitespace-pre-line";
             tipDiv.innerHTML = tip;


### PR DESCRIPTION
## Summary
- add prize tier configuration and code generation to award cleaning credits
- log prize tier and code to Google Sheet backend
- document prize probabilities and sheet columns

## Testing
- `npm test`
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b30984b92083228ef6365786ab3beb