### PR TITLE
feat: celebrate new high score

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,14 @@
         let FIRE_RATE = BASE_FIRE_RATE;
         let winStreak = 0;
         let timeOffset = 0; // server vs client clock diff
+        let highScore = Number(localStorage.getItem("highScore") || 0);
+
+        const highScoreMsg = document.createElement("div");
+        highScoreMsg.id = "highScoreMsg";
+        highScoreMsg.className =
+          "hidden fixed bottom-4 right-4 bg-emerald-600 text-white text-lg px-4 py-2 rounded-2xl shadow-lg z-50";
+        highScoreMsg.textContent = "You beat the high score! You are the BEST!!";
+        document.body.appendChild(highScoreMsg);
 
         if (typeof google !== "undefined") {
           google.script.run
@@ -428,6 +436,7 @@
         }
 
         function begin() {
+          highScoreMsg.classList.add("hidden");
           applyDifficulty();
           startScreen.classList.add("hidden");
           clearTimeout(bubbleTimer);
@@ -543,6 +552,11 @@
             } else {
               winStreak = 0;
             }
+            if (payload.score > highScore) {
+              highScore = payload.score;
+              localStorage.setItem("highScore", highScore);
+              showHighScoreBanner();
+            }
           } else {
             resultText.textContent =
               "Thanks for playing! Tap Play Again to try again.";
@@ -570,6 +584,13 @@
               zIndex: 1,
             });
           }
+        }
+
+        function showHighScoreBanner() {
+          highScoreMsg.classList.remove("hidden");
+          setTimeout(() => {
+            highScoreMsg.classList.add("hidden");
+          }, 5000);
         }
 
         function reset() {


### PR DESCRIPTION
## Summary
- show celebratory banner when player sets new high score
- persist and check high score using `localStorage`

## Testing
- `npm test`
- `npm run lint` (fails: No files matching the pattern "." were found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b30d5191108322a710b97846a25e7c