### PR TITLE
Fix Play Now button touch handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,13 +646,15 @@
           scheduleBubble();
         }
 
-        playBtn.addEventListener("click", () => {
+        playBtn.addEventListener("pointerdown", () => {
           startRound();
         });
-        document.getElementById("restartBtn").addEventListener("click", () => {
-          resultScreen.classList.add("hidden");
-          startRound();
-        });
+        document
+          .getElementById("restartBtn")
+          .addEventListener("pointerdown", () => {
+            resultScreen.classList.add("hidden");
+            startRound();
+          });
 
         scheduleBubble();
 


### PR DESCRIPTION
## Summary
- use `pointerdown` events for Play Now and Play Again buttons to ensure touch input works when touch actions are disabled

## Testing
- `npm run lint` (fails: No files matching the pattern "." were found)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30f4362e483228b6a21503f51553c