### PR TITLE
Wrap date under high score with reduced font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
 
     <div
       id="highScore"
-      class="hidden absolute bottom-2 right-2 z-50 text-2xl font-bold text-white bg-emerald-600 px-4 py-2 rounded-lg shadow-lg text-right"
+      class="hidden absolute bottom-2 right-2 z-50 text-[1.2rem] text-white bg-emerald-600 px-4 py-2 rounded-lg shadow-lg text-right"
     ></div>
 
     <script>
@@ -308,11 +308,11 @@
         function updateHighScoreDisplay() {
           const { score, timestamp } = loadHighScore();
           if (score > 0) {
-            highScoreEl.textContent = `High Score: ${score} (${new Date(
-              timestamp,
-            ).toLocaleString()})`;
+            highScoreEl.innerHTML = `
+<div class="font-bold">High Score: ${score}</div>
+<div>${new Date(timestamp).toLocaleString()}</div>`;
           } else {
-            highScoreEl.textContent = "High Score: 0";
+            highScoreEl.innerHTML = '<div class="font-bold">High Score: 0</div>';
           }
         }
 


### PR DESCRIPTION
## Summary
- Display high score timestamp on its own line and shrink both score and timestamp fonts
- Lower overall high score font size for readability

## Testing
- `npm test`
- `npm run lint` *(fails: No files matching the pattern "." were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3142d72b083229f43c83e200424db