### PR TITLE
feat: rename high score label

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,11 +264,11 @@
           const { score, timestamp } = loadHighScore();
           if (score > 0) {
             highScoreEl.innerHTML = `
-<div class="font-bold">High Score: ${score}</div>
+<div class="font-bold">Su-Stained High Score: ${score}</div>
 <div>${new Date(timestamp).toLocaleString()}</div>`;
           } else {
             highScoreEl.innerHTML =
-              '<div class="font-bold">High Score: 0</div>';
+              '<div class="font-bold">Su-Stained High Score: 0</div>';
           }
         }
 
@@ -569,7 +569,7 @@
             }
           }
           if (checkHighScore(payload.score)) {
-            resultText.textContent += " New High Score!";
+            resultText.textContent += " New Su-Stained High Score!";
           }
         }
 


### PR DESCRIPTION
## Summary
- replace "High Score" with "Su-Stained High Score" in the UI

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3364a099c8322a15c8b95b8093551