### PR TITLE
fix: ensure game starts when prize module missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,9 +150,16 @@
       class="hidden absolute bottom-2 right-2 z-50 text-[1.2rem] text-white bg-emerald-600 px-4 py-2 rounded-lg shadow-lg text-right"
     ></div>
 
-    <script type="module">
-      import { pickPrize } from "./prize.js";
-      (() => {
+    <script>
+      (async () => {
+        let pickPrize = () => ({
+          tier: "Common",
+          reward: null,
+          minLevel: 1,
+        });
+        try {
+          ({ pickPrize } = await import("./prize.js"));
+        } catch {}
         /* ----- Config ----- */
         const GAME_TIME = 12; // seconds
         const IS_MOBILE = window.innerWidth <= 414;


### PR DESCRIPTION
## Summary
- load `prize.js` dynamically with fallback so game initializes even if module fails
- remove top-level module import that prevented Play button, stains, and bubbles from working

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b34fcc5870832289b53ccb6c575168