### PR TITLE
Promote prize discounts in messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stain Blaster Kiosk Game
 
-An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to reveal a quick cleaning tip. The same build now scales down for phones, keeping the cannon visible and shrinking stains for added challenge.
+An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to reveal a quick cleaning tip and win prizes for discounts off your dry cleaning bill. The same build now scales down for phones, keeping the cannon visible and shrinking stains for added challenge.
 
 ## Kiosk/Iframe Build
 

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
         Stain Blaster
       </div>
       <div class="text-xl text-stone-500 text-center">
-        Swipe the stains away in 12 seconds<br />and reveal a cleaning tip!
+        Swipe the stains away in 12 seconds<br />for cleaning tips and prizes for discounts off your dry cleaning bill!
       </div>
       <div class="text-xs text-stone-400 text-center max-w-md px-4">
         By pressing "Play Now," you agree to our disclaimer: Ensure safe for
@@ -202,10 +202,10 @@
         ];
         const BUBBLE_LINES = [
           "Think you can wipe all the stains?",
-          "Eco cleaning tips await!",
-          "Swipe fast – tips await!",
-          "Spotless skills? Prove it!",
-          "Tap ▶ to blast and learn!",
+          "Eco cleaning tips & discounts await!",
+          "Swipe fast – win prizes toward your dry cleaning bill!",
+          "Spotless skills? Earn dry-cleaning credits!",
+          "Tap ▶ to blast, learn & save!",
           "Your dry-cleaner believes in you 😎",
         ];
         const BUBBLE_INTERVAL = 4000; // ms between spawns


### PR DESCRIPTION
## Summary
- Mention dry-cleaning prize discounts on start screen
- Add discount-focused lines to attract bubbles
- Document prize discount messaging in README

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3512f26548322b8ffa280fd5aec15