### PR TITLE
Start game immediately to reduce Play Now delay

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,15 +437,14 @@
         }
 
         function startRound() {
+          begin();
           if (typeof google !== "undefined") {
             google.script.run
               .withSuccessHandler((s) => {
                 winStreak = s;
-                begin();
               })
+              .withFailureHandler(() => {})
               .refreshStreakTimer();
-          } else {
-            begin();
           }
         }
 


### PR DESCRIPTION
## Summary
- Start the round right away instead of waiting for the Apps Script response.
- Refresh streak timer asynchronously so server latency doesn't delay gameplay.

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3558d846c8322a2bce1b7805d471f