### PR TITLE
Reset win streak on loss

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -94,3 +94,13 @@ function handleWin() {
   props.setProperty("winStreak", idx);
   return { winStreak: idx };
 }
+
+/**
+ * Reset the win streak after a loss so future games start at base difficulty.
+ * Returns zero for convenience so the client can update its local state.
+ */
+function resetStreak() {
+  const props = PropertiesService.getUserProperties();
+  props.deleteProperty("winStreak");
+  return { winStreak: 0 };
+}

--- a/index.html
+++ b/index.html
@@ -584,6 +584,12 @@
               google.script.run
                 .withFailureHandler(() => {})
                 .logGame(JSON.stringify(payload));
+              google.script.run
+                .withSuccessHandler((r) => {
+                  winStreak = r.winStreak;
+                })
+                .withFailureHandler(() => {})
+                .resetStreak();
             }
             winStreak = 0;
           }


### PR DESCRIPTION
## Summary
- Add `resetStreak` Apps Script helper to clear server-side streak
- Call `resetStreak` from client after a loss so difficulty reflects consecutive wins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3560f85248322b9ae2e2fed94bbc9