### PR TITLE
Prevent stale reset timer from interrupting new rounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,11 +169,13 @@
         const TOP_MARGIN = IS_MOBILE ? 10 : 50;
         const BOTTOM_MARGIN = IS_MOBILE ? 30 : 100;
         const DEVICE = IS_MOBILE ? "mobile" : "kiosk";
+        const RESET_DELAY = 30000; // ms to auto-reset result screen
         let STAIN_START = BASE_STAIN_START;
         let STAIN_SIZE = BASE_STAIN_SIZE;
         let FIRE_RATE = BASE_FIRE_RATE;
         let winStreak = 0;
         let timeOffset = 0; // server vs client clock diff
+        let resetTimer;
 
         if (typeof google !== "undefined") {
           google.script.run
@@ -449,6 +451,7 @@
         }
 
         function begin() {
+          clearTimeout(resetTimer);
           applyDifficulty();
           startScreen.classList.add("hidden");
           clearTimeout(bubbleTimer);
@@ -596,6 +599,10 @@
           if (checkHighScore(payload.score)) {
             resultText.textContent += " New High Score!";
           }
+          clearTimeout(resetTimer);
+          resetTimer = setTimeout(() => {
+            if (!resultScreen.classList.contains("hidden")) reset();
+          }, RESET_DELAY);
         }
 
         function confetti() {
@@ -610,6 +617,7 @@
         }
 
         function reset() {
+          clearTimeout(resetTimer);
           resultScreen.classList.add("hidden");
           startScreen.classList.remove("hidden");
           resultShown = false;
@@ -628,15 +636,6 @@
           });
 
         scheduleBubble();
-
-        setInterval(() => {
-          if (
-            !resultScreen.classList.contains("hidden") &&
-            now() - startTime > (GAME_TIME + 30) * 1000
-          ) {
-            reset();
-          }
-        }, 5000);
       })();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add a dedicated `resetTimer` and delay constant to manage auto-reset behavior
- clear pending reset timer when a new round begins
- schedule and guard reset calls so old timers can't interrupt later rounds

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3573062c0832296232723846430ba