### PR TITLE
Remove mobile and iframe support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,5 @@ Kiosk build with restricted features removed:
 
 - [x] Audio removed (fixed 404: `splat.mp3`)
 - [x] Geolocation, camera, microphone, sensors, MIDI, Payment, USB/Bluetooth, WakeLock, Clipboard, Web Share, Fullscreen — **not used**
-- [x] Iframe mode enabled via `XFrameOptionsMode.ALLOWALL`
 - [x] No autoplay / no media elements
 

--- a/Code.gs
+++ b/Code.gs
@@ -3,7 +3,7 @@
  * Google Apps Script backend (HTML Service)
  * ------------------------------------------
  * Logs game results to a Google Sheet and serves index.html.
- * Supports both kiosk and mobile plays; client reports device type.
+ * Touchscreen kiosk only; client reports device type.
  *
  * 1.  Deploy as a Web App → “Execute as Me”, “Anyone”.
  * 2.  Add your Sheet ID below or create one named “StainBlasterLog”.
@@ -16,16 +16,16 @@ const HEADERS = [
   "Stains cleared",
   "Stains missed",
   "Seconds taken",
-  "Device", // 'kiosk' or 'mobile'
+  "Device", // kiosk label
   "Prize Tier",
   "Prize Code",
 ];
 
 /** Serve the kiosk page */
 function doGet() {
-  return HtmlService.createHtmlOutputFromFile("index")
-    .setTitle("Dublin Cleaners Game")
-    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+  return HtmlService.createHtmlOutputFromFile("index").setTitle(
+    "Dublin Cleaners Game",
+  );
 }
 
 /** Append one row of JSON-encoded data from client */

--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
 # Stain Blaster Kiosk Game
 
-An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to reveal a quick cleaning tip and win prizes for discounts off your dry cleaning bill. The same build now scales down for phones, keeping the cannon visible and shrinking stains for added challenge.
+An ✨ 12-second touch game for Dublin Cleaners’ 55″ Elo ET5502L portrait kiosk. Guests wipe stains off a crisp white dress shirt while a cartoony cannon lobs extra splatters; clear them all to reveal a quick cleaning tip and win prizes for discounts off your dry cleaning bill.
 
-## Kiosk/Iframe Build
+## Kiosk Build
 
-This kiosk-focused build removes all audio and restricted browser APIs. Apps Script is configured with `XFrameOptionsMode.ALLOWALL` so the game can be embedded inside iframes without permission errors.
-
-```html
-<iframe
-  src="https://script.google.com/macros/s/AKfycbwACMboC3x2m_9Sg1f_-HXYzpG3bnA81rYp3ra-q4vOttXJNKVag3uCLnmt9IsaEfI1/exec" 
-  width="1080"
-  height="1920"
-  style="border:0; aspect-ratio: 9/16;"
-  sandbox="allow-scripts allow-same-origin"
-></iframe>
-```
-
-> The iframe intentionally omits `allow` tokens for geolocation, camera, microphone, fullscreen, clipboard, payments, and other restricted features. Permissions are fully controlled by the outer page.
+This kiosk-focused build removes all audio and restricted browser APIs.
 
 ## Stack
 * **Google Apps Script (HTML Service)** – one `Code.gs` backend.
@@ -48,8 +36,6 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 * Players can start a new round immediately after each game.
 * Consecutive wins continue to ramp difficulty to keep the challenge lively.
 
-## Mobile Optimizations
-* Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.
 
 ## Cleaning Tips
 * Every round ends with a rotating eco-friendly cleaning tip to reinforce garment care.
@@ -72,7 +58,7 @@ Each play logs a row to the Google Sheet with the following columns:
 | B      | Stains cleared | Number of stains the player removed     |
 | C      | Stains missed  | Stains left when time expired           |
 | D      | Seconds taken  | Duration of the game in seconds         |
-| E      | Device         | Source device label (kiosk or mobile)   |
+| E      | Device         | Source device label (kiosk)             |
 | F      | Prize Tier     | Awarded tier (Common/Uncommon/Rare/Epic) |
 | G      | Prize Code     | Unique code for credit prizes           |
 
@@ -80,8 +66,8 @@ Monitor play counts and difficulty; pivot by day for analytics.
 
 ## Local Assets
 * **Shirt background** – 1080 × 1920 PNG of a pressed white dress shirt.
-* **Stain sprites** – semi-transparent PNG splatters (~90 px) with drop shadow; phones render them ~25 % smaller.
-* **Cannon sprite** – small, cartoony launcher anchored bottom-right; shrinks on phones so it never covers the Play button.
+* **Stain sprites** – semi-transparent PNG splatters (~90 px) with drop shadow.
+* **Cannon sprite** – small, cartoony launcher anchored bottom-right.
 All images can be swapped by editing `index.html`.
 
 ## License

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- Kiosk build: audio & restricted APIs removed for iframe compatibility -->
+<!-- Kiosk build: audio & restricted APIs removed -->
 <html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
@@ -22,16 +22,6 @@
         transform-origin: bottom right;
         pointer-events: none;
         z-index: 50;
-      }
-      @media (max-width: 414px) {
-        #cannon {
-          width: 120px;
-          bottom: 0.5rem;
-          right: 0.5rem;
-        }
-        #startScreen {
-          padding-bottom: 6rem;
-        }
       }
       .bubble {
         position: absolute;
@@ -162,13 +152,12 @@
         } catch {}
         /* ----- Config ----- */
         const GAME_TIME = 12; // seconds
-        const IS_MOBILE = window.innerWidth <= 414;
-        const BASE_STAIN_START = 23; // initial stains (50% more)
-        const BASE_STAIN_SIZE = IS_MOBILE ? 68 : 90; // px (smaller on phones)
-        const BASE_FIRE_RATE = IS_MOBILE ? 1500 : 3000; // ms per extra stain (faster on phones)
-        const TOP_MARGIN = IS_MOBILE ? 10 : 50;
-        const BOTTOM_MARGIN = IS_MOBILE ? 30 : 100;
-        const DEVICE = IS_MOBILE ? "mobile" : "kiosk";
+        const BASE_STAIN_START = 23; // initial stains
+        const BASE_STAIN_SIZE = 90; // px
+        const BASE_FIRE_RATE = 3000; // ms per extra stain
+        const TOP_MARGIN = 50;
+        const BOTTOM_MARGIN = 100;
+        const DEVICE = "kiosk";
         let STAIN_START = BASE_STAIN_START;
         let STAIN_SIZE = BASE_STAIN_SIZE;
         let FIRE_RATE = BASE_FIRE_RATE;
@@ -386,11 +375,7 @@
             remaining--;
             if (remaining === 0 && seconds > 0) win();
           };
-          if (IS_MOBILE) {
-            s.addEventListener("touchstart", remove, { passive: true });
-          } else {
-            s.addEventListener("pointerdown", remove);
-          }
+          s.addEventListener("pointerdown", remove);
           gameArea.appendChild(s);
           remaining++;
           total++;
@@ -475,7 +460,6 @@
             }
           }, 1000);
           fireInterval = setInterval(fireCannon, FIRE_RATE);
-          if (IS_MOBILE) setTimeout(fireCannon, FIRE_RATE / 2);
         }
 
         function win() {


### PR DESCRIPTION
## Summary
- Simplify backend for kiosk-only deployment and drop iframe allowance.
- Strip mobile-specific logic from the game client so constants and inputs target kiosks.
- Clean up documentation to reflect kiosk-only focus and remove iframe guidance.

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b357f710108322836e41ca7b1c9ef0