### PR TITLE
Fix prize distribution fairness across levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 
 ```html
 <iframe
-  src="https://script.google.com/macros/s/AKfycbwACMboC3x2m_9Sg1f_-HXYzpG3bnA81rYp3ra-q4vOttXJNKVag3uCLnmt9IsaEfI1/exec" 
+  src="https://script.google.com/macros/s/AKfycbwACMboC3x2m_9Sg1f_-HXYzpG3bnA81rYp3ra-q4vOttXJNKVag3uCLnmt9IsaEfI1/exec"
   width="1080"
   height="1920"
   style="border:0; aspect-ratio: 9/16;"
@@ -19,13 +19,15 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 > The iframe intentionally omits `allow` tokens for geolocation, camera, microphone, fullscreen, clipboard, payments, and other restricted features. Permissions are fully controlled by the outer page.
 
 ## Stack
-* **Google Apps Script (HTML Service)** – one `Code.gs` backend.
-* **Tailwind CSS via CDN** – rapid, utility-first styling.
-* **Vanilla JS** – fast, dependency-light touch handling.
-* **canvas-confetti** CDN – celebration effects.
-* **Google Sheets** – game logging for analytics.
+
+- **Google Apps Script (HTML Service)** – one `Code.gs` backend.
+- **Tailwind CSS via CDN** – rapid, utility-first styling.
+- **Vanilla JS** – fast, dependency-light touch handling.
+- **canvas-confetti** CDN – celebration effects.
+- **Google Sheets** – game logging for analytics.
 
 ## Quick Start
+
 1. The provided `Code.gs` logs to [this Google Sheet](https://docs.google.com/spreadsheets/d/17k6TfJeAERydKa0L0vAXRp6y0q3zckB35dFv9qfDQ6g/edit) by default.
 2. If using a different spreadsheet, update the `SHEET_ID` constant in `Code.gs`.
 3. Add an **HTML** file named `index` and paste `index.html`.
@@ -33,60 +35,72 @@ This kiosk-focused build removes all audio and restricted browser APIs. Apps Scr
 5. Point EloView/Yodeck to this URL (ensure portrait 1080×1920).
 
 ## Attract Bubbles
-* Start screen spawns playful speech bubbles every ~4 s (±1 s jitter).
-* Lines rotate from the `BUBBLE_LINES` array; edit or fetch at runtime to change copy.
-* Animations use `bubble-in` (scale/bounce fade-in) and `bubble-out` (fade-out after 5 s).
-* Tweak cadence via `BUBBLE_INTERVAL`/`BUBBLE_JITTER` without redeploying by loading config from GAS.
+
+- Start screen spawns playful speech bubbles every ~4 s (±1 s jitter).
+- Lines rotate from the `BUBBLE_LINES` array; edit or fetch at runtime to change copy.
+- Animations use `bubble-in` (scale/bounce fade-in) and `bubble-out` (fade-out after 5 s).
+- Tweak cadence via `BUBBLE_INTERVAL`/`BUBBLE_JITTER` without redeploying by loading config from GAS.
 
 ## Dynamic Difficulty
-* Consecutive wins ramp up the challenge.
-* Each streak shrinks stains ~20 %, adds ~15 % more splatters, and speeds the cannon by ~15 %.
-* Losing resets the streak and returns to base difficulty.
-* Streak resets after 5 minutes of inactivity but never blocks play.
+
+- Consecutive wins ramp up the challenge.
+- Each streak shrinks stains ~20 %, adds ~15 % more splatters, and speeds the cannon by ~15 %.
+- Losing resets the streak and returns to base difficulty.
+- Streak resets after 5 minutes of inactivity but never blocks play.
 
 ## Replay Policy
-* Players can start a new round immediately after each game.
-* Consecutive wins continue to ramp difficulty to keep the challenge lively.
+
+- Players can start a new round immediately after each game.
+- Consecutive wins continue to ramp difficulty to keep the challenge lively.
 
 ## Mobile Optimizations
-* Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.
+
+- Phones render smaller stains, spread them across a wider vertical range, and clear with a quick tap.
 
 ## Cleaning Tips
-* Every round ends with a rotating eco-friendly cleaning tip to reinforce garment care.
+
+- Every round ends with a rotating eco-friendly cleaning tip to reinforce garment care.
 
 ## Prize Tiers
 
-| Tier      | Probability | Reward                                  | Notes                                                                 |
-| --------- | ----------- | --------------------------------------- | --------------------------------------------------------------------- |
-| Common    | 60%         | Cleaning Tip                            | No monetary value                                                     |
-| Uncommon  | 25%         | $5 cleaning credit                      | Take a Photo of Credit & Show to CSR for Credit                       |
-| Rare      | 12%         | $10 cleaning credit (Level 2+)          | Take a Photo of Credit & Show to CSR for Credit                       |
-| Epic      | 3%          | $50 premium garment credit (Level 3+)   | 1/day cap, manager approval. Take a Photo of Credit & Show to CSR     |
+| Tier     | Probability | Reward                                | Notes                                                             |
+| -------- | ----------- | ------------------------------------- | ----------------------------------------------------------------- |
+| Common   | 60%         | Cleaning Tip                          | No monetary value                                                 |
+| Uncommon | 25%         | $5 cleaning credit                    | Take a Photo of Credit & Show to CSR for Credit                   |
+| Rare     | 12%         | $10 cleaning credit (Level 2+)        | Take a Photo of Credit & Show to CSR for Credit                   |
+| Epic     | 3%          | $50 premium garment credit (Level 3+) | 1/day cap, manager approval. Take a Photo of Credit & Show to CSR |
+
+> Probabilities for locked tiers roll down to the Common tier so that
+> lower-level players keep the advertised odds for the remaining prizes (e.g. Uncommon stays at 25%).
 
 ## Sheet Schema
+
 Each play logs a row to the Google Sheet with the following columns:
 
-| Column | Header         | Purpose                                 |
-| ------ | -------------- | --------------------------------------- |
-| A      | Timestamp      | When the result was recorded            |
-| B      | Stains cleared | Number of stains the player removed     |
-| C      | Stains missed  | Stains left when time expired           |
-| D      | Seconds taken  | Duration of the game in seconds         |
-| E      | Device         | Source device label (kiosk or mobile)   |
+| Column | Header         | Purpose                                  |
+| ------ | -------------- | ---------------------------------------- |
+| A      | Timestamp      | When the result was recorded             |
+| B      | Stains cleared | Number of stains the player removed      |
+| C      | Stains missed  | Stains left when time expired            |
+| D      | Seconds taken  | Duration of the game in seconds          |
+| E      | Device         | Source device label (kiosk or mobile)    |
 | F      | Prize Tier     | Awarded tier (Common/Uncommon/Rare/Epic) |
-| G      | Prize Code     | Unique code for credit prizes           |
+| G      | Prize Code     | Unique code for credit prizes            |
 
 Monitor play counts and difficulty; pivot by day for analytics.
 
 ## Local Assets
-* **Shirt background** – 1080 × 1920 PNG of a pressed white dress shirt.
-* **Stain sprites** – semi-transparent PNG splatters (~90 px) with drop shadow; phones render them ~25 % smaller.
-* **Cannon sprite** – small, cartoony launcher anchored bottom-right; shrinks on phones so it never covers the Play button.
-All images can be swapped by editing `index.html`.
+
+- **Shirt background** – 1080 × 1920 PNG of a pressed white dress shirt.
+- **Stain sprites** – semi-transparent PNG splatters (~90 px) with drop shadow; phones render them ~25 % smaller.
+- **Cannon sprite** – small, cartoony launcher anchored bottom-right; shrinks on phones so it never covers the Play button.
+  All images can be swapped by editing `index.html`.
 
 ## License
+
 Internal use only – Dublin Cleaners. Fork freely inside org.
 
 ## v2 Addendum
-* Rounds locked to 12 seconds.
-* Difficulty scales exponentially each level via stain count/size/spawn interval curve.
+
+- Rounds locked to 12 seconds.
+- Difficulty scales exponentially each level via stain count/size/spawn interval curve.

--- a/prize.js
+++ b/prize.js
@@ -20,15 +20,20 @@ export const PRIZES = [
   },
 ];
 
+// Picks a prize based on the configured probabilities while ensuring
+// players never receive locked tiers. Probability mass from locked
+// tiers falls back to the first available tier ("Common"), keeping the
+// advertised odds for the remaining prizes consistent across levels.
 export function pickPrize(level) {
-  const available = PRIZES.filter((p) => level >= p.minLevel);
-  const total = available.reduce((sum, p) => sum + p.probability, 0);
-  let r = Math.random() * total;
-  for (const p of available) {
-    if (r < p.probability) {
-      return p;
+  const fallback = PRIZES.find((p) => level >= p.minLevel);
+  if (!fallback) return PRIZES[0];
+  const r = Math.random();
+  let cumulative = 0;
+  for (const p of PRIZES) {
+    cumulative += p.probability;
+    if (r < cumulative) {
+      return level >= p.minLevel ? p : fallback;
     }
-    r -= p.probability;
   }
-  return available[0];
+  return fallback;
 }

--- a/prize.test.js
+++ b/prize.test.js
@@ -3,11 +3,17 @@ import assert from "node:assert/strict";
 import { PRIZES, pickPrize } from "./prize.js";
 
 function expected(level) {
-  const available = PRIZES.filter((p) => level >= p.minLevel);
-  const total = available.reduce((sum, p) => sum + p.probability, 0);
+  const fallback = PRIZES.find((p) => level >= p.minLevel);
   const result = {};
-  for (const p of available) {
-    result[p.tier] = p.probability / total;
+  for (const p of PRIZES) {
+    result[p.tier] = 0;
+  }
+  for (const p of PRIZES) {
+    if (level >= p.minLevel) {
+      result[p.tier] += p.probability;
+    } else {
+      result[fallback.tier] += p.probability;
+    }
   }
   return result;
 }
@@ -35,7 +41,7 @@ test("pickPrize returns only allowed prizes", () => {
 
 test("pickPrize distribution is fair", () => {
   const ITER = 100000;
-  const tolerance = 0.02; // 2%
+  const tolerance = 0.01; // 1%
   for (const level of [1, 2, 3]) {
     const counts = simulate(level, ITER);
     const exp = expected(level);


### PR DESCRIPTION
## Summary
- ensure locked prize tiers fall back to Common so advertised odds remain consistent
- test prize selection distribution with 1% tolerance across levels
- document prize fallback behavior

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b358acb20c8322b33bc2c1a27d539d