### PR TITLE
Fix countdown timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,8 @@
         const TOP_MARGIN = 50;
         const BOTTOM_MARGIN = 100;
         const DEVICE = "kiosk";
+        const GAME_TIME = 12; // seconds per round
+        const RESET_DELAY = 15_000; // ms before auto reset
 
         let STAIN_START = BASE_STAIN_START;
         let STAIN_SIZE = BASE_STAIN_SIZE;


### PR DESCRIPTION
## Summary
- ensure game round timer is defined and countdown starts from 12 seconds
- add reset delay constant for result screen auto-reset

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b35962a16c8322bc8f0d03469e5a52