### PR TITLE
Increase post-game reset delay

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
         const BOTTOM_MARGIN = 100;
         const DEVICE = "kiosk";
         const GAME_TIME = 12; // seconds per round
-        const RESET_DELAY = 15_000; // ms before auto reset
+        const RESET_DELAY = 60_000; // ms before auto reset (4x longer)
 
         let STAIN_START = BASE_STAIN_START;
         let STAIN_SIZE = BASE_STAIN_SIZE;


### PR DESCRIPTION
## Summary
- Extend reset delay after win or loss to 60 seconds so players have four times longer before the game restarts.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3609d96448322b2c64785edca95cd