### PR TITLE
Fix typo in post-game share message

### DIFF
--- a/index.html
+++ b/index.html
@@ -572,7 +572,7 @@
               const shareEl = document.createElement("div");
               shareEl.className = "text-sm text-stone-600 text-center";
               shareEl.innerHTML =
-                'Share with your friends your Winnings & Hight Scores to social. Tag us @dublincleaners on Facebook and/or Instagram.<span class="inline-flex items-center gap-1 ml-1"><img src="https://cdn.simpleicons.org/facebook/1877F2" alt="Facebook logo" class="h-4 w-4" /><img src="https://cdn.simpleicons.org/instagram/E4405F" alt="Instagram logo" class="h-4 w-4" /></span>';
+                'Share with your friends your Winnings & High Scores to social. Tag us @dublincleaners on Facebook and/or Instagram.<span class="inline-flex items-center gap-1 ml-1"><img src="https://cdn.simpleicons.org/facebook/1877F2" alt="Facebook logo" class="h-4 w-4" /><img src="https://cdn.simpleicons.org/instagram/E4405F" alt="Instagram logo" class="h-4 w-4" /></span>';
               qrWrap.appendChild(shareEl);
               code = genCode();
               payload.prizeCode = code;


### PR DESCRIPTION
## Summary
- correct "Hight Scores" typo to "High Scores" in prize announcement share message

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b361bc0eb883229c6cbb93abf5b178