### PR TITLE
Center timer and reposition high score

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
       <!-- stains injected here -->
       <div
         id="timer"
-        class="absolute top-6 left-1/2 -translate-x-1/2 text-5xl font-bold text-white drop-shadow"
+        class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-8xl font-black text-yellow-400 drop-shadow-lg"
       >
         12
       </div>
@@ -157,7 +157,7 @@
 
     <div
       id="highScore"
-      class="hidden absolute bottom-2 right-2 z-50 text-[1.2rem] text-white bg-emerald-600 px-4 py-2 rounded-lg shadow-lg text-right"
+      class="hidden absolute top-2 right-2 z-50 text-[1.2rem] text-white bg-emerald-600 px-4 py-2 rounded-lg shadow-lg text-right"
     ></div>
 
     <script>


### PR DESCRIPTION
## Summary
- Center countdown timer and enlarge its style
- Move Su-Stained high score display to the top-right of the screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f679199483229a8e5b2ddd796083