### PR TITLE
Add cannon glitch effect and clearer result messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         filter: drop-shadow(2px 2px 3px rgba(0, 0, 0, 0.4));
         z-index: 10;
       }
-      #cannon {
+      .glitch-cannon {
         position: absolute;
         width: 220px;
         height: auto;
@@ -23,18 +23,17 @@
         pointer-events: none;
         z-index: 50;
       }
-      #logo {
+      .glitch-shell {
         position: relative;
         display: inline-block;
         transform-origin: center;
       }
-      #logo .logo-main {
+      .glitch-shell .glitch-main {
         display: block;
         width: 100%;
         height: auto;
-        filter: drop-shadow(0 18px 38px rgba(16, 185, 129, 0.35));
       }
-      #logo .logo-layer {
+      .glitch-shell .glitch-layer {
         position: absolute;
         top: 0;
         left: 0;
@@ -44,11 +43,14 @@
         pointer-events: none;
         mix-blend-mode: screen;
       }
-      #logo .logo-layer--red {
+      .glitch-shell .glitch-layer--red {
         filter: hue-rotate(-45deg) saturate(260%) brightness(1.2);
       }
-      #logo .logo-layer--cyan {
+      .glitch-shell .glitch-layer--cyan {
         filter: hue-rotate(160deg) saturate(240%) brightness(1.2);
+      }
+      #logo .glitch-main {
+        filter: drop-shadow(0 18px 38px rgba(16, 185, 129, 0.35));
       }
 
       #highScoreModal {
@@ -177,13 +179,13 @@
         animation: flash 1s infinite;
       }
 
-      .logo-glitch .logo-main {
+      .glitch-active .glitch-main {
         animation: logo-glitch-base 1.1s steps(2, end);
       }
-      .logo-glitch .logo-layer--red {
+      .glitch-active .glitch-layer--red {
         animation: logo-glitch-layer-red 1.1s steps(2, end);
       }
-      .logo-glitch .logo-layer--cyan {
+      .glitch-active .glitch-layer--cyan {
         animation: logo-glitch-layer-cyan 1.1s steps(2, end);
       }
 
@@ -311,24 +313,24 @@
     >
       <div
         id="logo"
-        class="relative w-72 md:w-80 max-w-sm drop-shadow-2xl transition-transform duration-700 ease-out"
+        class="glitch-shell relative w-72 md:w-80 max-w-sm drop-shadow-2xl transition-transform duration-700 ease-out"
       >
         <img
           src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
           alt="Dublin Cleaners"
-          class="logo-main"
+          class="glitch-main"
         />
         <img
           src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
           alt=""
           aria-hidden="true"
-          class="logo-layer logo-layer--red"
+          class="glitch-layer glitch-layer--red"
         />
         <img
           src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
           alt=""
           aria-hidden="true"
-          class="logo-layer logo-layer--cyan"
+          class="glitch-layer glitch-layer--cyan"
         />
       </div>
       <div class="text-5xl font-bold text-stone-700 text-center leading-tight">
@@ -352,14 +354,29 @@
       >
         Play Now
       </button>
+      <div
+        id="attractCannon"
+        class="glitch-shell glitch-cannon select-none"
+        aria-hidden="true"
+      >
+        <img
+          src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
+          alt=""
+          class="glitch-main"
+        />
+        <img
+          src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
+          alt=""
+          class="glitch-layer glitch-layer--red"
+        />
+        <img
+          src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
+          alt=""
+          class="glitch-layer glitch-layer--cyan"
+        />
+      </div>
     </div>
 
-    <img
-      id="cannon"
-      src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
-      alt="cannon"
-      class="select-none"
-    />
 
     <!-- Game Area -->
     <div
@@ -367,6 +384,27 @@
       class="absolute inset-0 hidden bg-[url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Whiteshirt.png')] bg-cover"
     >
       <!-- stains injected here -->
+      <div
+        id="cannon"
+        class="glitch-shell glitch-cannon select-none"
+        aria-hidden="true"
+      >
+        <img
+          src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
+          alt=""
+          class="glitch-main"
+        />
+        <img
+          src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
+          alt=""
+          class="glitch-layer glitch-layer--red"
+        />
+        <img
+          src="https://www.dublincleaners.com/wp-content/uploads/2025/08/Canon.png"
+          alt=""
+          class="glitch-layer glitch-layer--cyan"
+        />
+      </div>
       <div
         id="timer"
         class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-8xl font-black text-yellow-400 drop-shadow-lg"
@@ -380,7 +418,10 @@
       id="resultScreen"
       class="absolute inset-0 hidden flex flex-col items-center justify-center gap-6 bg-white text-center"
     >
-      <div id="resultText" class="text-4xl font-semibold text-stone-700"></div>
+      <div
+        id="resultText"
+        class="flex flex-col items-center gap-4 text-center"
+      ></div>
       <div id="qrWrap" class="p-4 bg-stone-100 rounded-2xl shadow-inner"></div>
       <button
         id="restartBtn"
@@ -621,6 +662,7 @@
         const gameArea = document.getElementById("gameArea");
         const timerEl = document.getElementById("timer");
         const cannon = document.getElementById("cannon");
+        const attractCannon = document.getElementById("attractCannon");
         const resultScreen = document.getElementById("resultScreen");
         const resultText = document.getElementById("resultText");
         const qrWrap = document.getElementById("qrWrap");
@@ -721,8 +763,9 @@
           fireInterval,
           bubbleTimer,
           logoTimer,
-          logoGlitchCleanup,
           resultShown = false;
+
+        const glitchTimers = new Map();
 
         let inMemoryHighScore = { score: 0, name: "", timestamp: 0 };
 
@@ -1007,16 +1050,30 @@
           );
         }
 
-        function triggerLogoGlitch() {
-          if (!logo) return;
-          logo.classList.remove("logo-glitch");
-          // Force reflow so the animation can restart even if the class is present.
-          void logo.offsetWidth;
-          logo.classList.add("logo-glitch");
-          clearTimeout(logoGlitchCleanup);
-          logoGlitchCleanup = setTimeout(() => {
-            logo.classList.remove("logo-glitch");
+        function triggerGlitchFor(element) {
+          if (!element) return;
+          element.classList.remove("glitch-active");
+          void element.offsetWidth;
+          element.classList.add("glitch-active");
+          const timer = glitchTimers.get(element);
+          if (timer) {
+            clearTimeout(timer);
+          }
+          const cleanup = setTimeout(() => {
+            element.classList.remove("glitch-active");
+            glitchTimers.delete(element);
           }, LOGO_GLITCH_DURATION);
+          glitchTimers.set(element, cleanup);
+        }
+
+        function triggerLogoGlitch() {
+          if (!startScreen.classList.contains("hidden")) {
+            triggerGlitchFor(logo);
+            triggerGlitchFor(attractCannon);
+          }
+          if (!gameArea.classList.contains("hidden")) {
+            triggerGlitchFor(cannon);
+          }
         }
 
         function scheduleLogoGlitch(initialDelay = LOGO_GLITCH_INTERVAL) {
@@ -1024,9 +1081,7 @@
           const jitter = Math.random() * LOGO_GLITCH_JITTER;
           const delay = Math.max(0, initialDelay) + jitter;
           logoTimer = setTimeout(() => {
-            if (!startScreen.classList.contains("hidden")) {
-              triggerLogoGlitch();
-            }
+            triggerLogoGlitch();
             scheduleLogoGlitch(LOGO_GLITCH_INTERVAL);
           }, delay);
         }
@@ -1124,6 +1179,8 @@
           clearTimeout(bubbleTimer);
           startScreen.querySelectorAll(".bubble").forEach((b) => b.remove());
           gameArea.classList.remove("hidden");
+          triggerLogoGlitch();
+          scheduleLogoGlitch(0);
           gameArea.querySelectorAll(".stain").forEach((s) => s.remove());
           if (!gameArea.contains(timerEl)) gameArea.appendChild(timerEl);
           remaining = 0;
@@ -1159,6 +1216,21 @@
           showResult(false);
         }
 
+        function setResultMessage(title, body, status) {
+          if (!resultText) return;
+          resultText.replaceChildren();
+          const heading = document.createElement("div");
+          const toneClass =
+            status === "win" ? "text-emerald-500" : "text-rose-500";
+          heading.className = `text-6xl font-black drop-shadow-sm ${toneClass}`;
+          heading.textContent = title;
+          const bodyEl = document.createElement("div");
+          bodyEl.className = "text-2xl font-semibold text-stone-700";
+          bodyEl.textContent = body;
+          resultText.appendChild(heading);
+          resultText.appendChild(bodyEl);
+        }
+
         function showResult(success) {
           if (resultShown) return;
           resultShown = true;
@@ -1166,7 +1238,6 @@
           resultScreen.classList.remove("hidden");
           qrWrap.innerHTML = "";
           qrWrap.className = "p-4 bg-stone-100 rounded-2xl shadow-inner";
-          resultText.textContent = "";
           const payload = {
             score: total - remaining,
             missed: remaining,
@@ -1182,11 +1253,11 @@
             const prize = pickPrize(level);
             payload.prizeTier = prize.tier;
             let code = "";
-            if (prize.tier === "Common") {
-              resultText.textContent = "Great job! Enjoy this cleaning tip 🌱";
-            } else {
-              resultText.textContent = `Great job! You won ${prize.reward}!`;
-            }
+            const winMessage =
+              prize.tier === "Common"
+                ? "Great job! Enjoy this cleaning tip 🌱"
+                : `Great job! You won ${prize.reward}!`;
+            setResultMessage("You Won!", winMessage, "win");
             qrWrap.className =
               "p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg";
             if (prize.tier !== "Common") {
@@ -1249,8 +1320,11 @@
               winStreak = 0;
             }
           } else {
-            resultText.textContent =
-              "Thanks for playing! Tap Play Again to try again.";
+            setResultMessage(
+              "You Lost!",
+              "Thanks for playing! Tap Play Again to try again.",
+              "lose",
+            );
             qrWrap.className =
               "p-6 bg-emerald-50 rounded-2xl shadow-md flex flex-col items-center gap-4 max-w-lg";
             const tipDiv = document.createElement("div");
@@ -1352,9 +1426,7 @@
             startRound();
           });
 
-        if (!startScreen.classList.contains("hidden")) {
-          triggerLogoGlitch();
-        }
+        triggerLogoGlitch();
         scheduleLogoGlitch();
         scheduleBubble();
       })();


### PR DESCRIPTION
## Summary
- add reusable glitch styling and apply it to the start screen logo and both cannons
- render a cannon on the game screen and trigger its glitch animation while rounds are running
- streamline the result view with explicit "You Won"/"You Lost" messaging driven by a helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e360f72c8322a7798757ff901c2a