### PR TITLE
Fix kiosk reset delay constant for legacy browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@
         const BOTTOM_MARGIN = 100;
         const DEVICE = "kiosk";
         const GAME_TIME = 12; // seconds per round
-        const RESET_DELAY = 60_000; // ms before auto reset (4x longer)
+        const RESET_DELAY = 60000; // ms before auto reset (4x longer)
 
         let STAIN_START = BASE_STAIN_START;
         let STAIN_SIZE = BASE_STAIN_SIZE;


### PR DESCRIPTION
## Summary
- replace the numeric separator in the `RESET_DELAY` constant so the inline script parses on older browsers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ff0d94d48322937ead71b101e079