### PR TITLE
Increase glitch animation prominence

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,25 +219,25 @@
           transform: translate3d(0, 0, 0);
         }
         13% {
-          transform: translate3d(-2px, 1px, 0) skewX(-2deg);
+          transform: translate3d(-5px, 2px, 0) skewX(-4deg);
         }
         15% {
-          transform: translate3d(3px, -2px, 0) skewX(2deg);
+          transform: translate3d(5px, -3px, 0) skewX(3deg);
         }
         18% {
-          transform: translate3d(-1px, 1px, 0);
+          transform: translate3d(-3px, 2px, 0);
         }
         56% {
-          transform: translate3d(2px, -1px, 0) skewX(1deg);
+          transform: translate3d(4px, -2px, 0) skewX(2deg);
         }
         60% {
-          transform: translate3d(-2px, 2px, 0) skewX(-1deg);
+          transform: translate3d(-4px, 3px, 0) skewX(-2deg);
         }
         83% {
-          transform: translate3d(-1px, -2px, 0);
+          transform: translate3d(-3px, -3px, 0);
         }
         86% {
-          transform: translate3d(2px, 1px, 0);
+          transform: translate3d(4px, 2px, 0);
         }
       }
 
@@ -255,32 +255,32 @@
           clip-path: inset(0 0 0 0);
         }
         13% {
-          opacity: 0.7;
-          transform: translate3d(-3px, -2px, 0);
-          clip-path: inset(0 0 55% 0);
+          opacity: 0.85;
+          transform: translate3d(-6px, -4px, 0);
+          clip-path: inset(0 0 60% 0);
         }
         15% {
-          opacity: 0.7;
-          transform: translate3d(3px, 1px, 0);
-          clip-path: inset(45% 0 0 0);
+          opacity: 0.85;
+          transform: translate3d(5px, 2px, 0);
+          clip-path: inset(40% 0 0 0);
         }
         18% {
           opacity: 0;
         }
         56% {
-          opacity: 0.6;
-          transform: translate3d(-2px, 1px, 0);
-          clip-path: inset(0 0 65% 0);
+          opacity: 0.75;
+          transform: translate3d(-4px, 2px, 0);
+          clip-path: inset(0 0 70% 0);
         }
         60% {
-          opacity: 0.6;
-          transform: translate3d(2px, -1px, 0);
-          clip-path: inset(35% 0 0 0);
+          opacity: 0.75;
+          transform: translate3d(4px, -2px, 0);
+          clip-path: inset(30% 0 0 0);
         }
         83% {
-          opacity: 0.75;
-          transform: translate3d(-3px, 0, 0);
-          clip-path: inset(15% 0 45% 0);
+          opacity: 0.9;
+          transform: translate3d(-5px, 0, 0);
+          clip-path: inset(10% 0 35% 0);
         }
       }
 
@@ -298,27 +298,27 @@
           clip-path: inset(0 0 0 0);
         }
         13% {
-          opacity: 0.7;
-          transform: translate3d(3px, 1px, 0);
-          clip-path: inset(45% 0 0 0);
+          opacity: 0.85;
+          transform: translate3d(5px, 2px, 0);
+          clip-path: inset(35% 0 0 0);
         }
         15% {
-          opacity: 0.7;
-          transform: translate3d(-2px, -1px, 0);
-          clip-path: inset(0 0 40% 0);
+          opacity: 0.85;
+          transform: translate3d(-4px, -2px, 0);
+          clip-path: inset(0 0 35% 0);
         }
         18% {
           opacity: 0;
         }
         57% {
-          opacity: 0.6;
-          transform: translate3d(2px, -2px, 0);
-          clip-path: inset(20% 0 40% 0);
+          opacity: 0.7;
+          transform: translate3d(4px, -3px, 0);
+          clip-path: inset(15% 0 35% 0);
         }
         84% {
-          opacity: 0.7;
-          transform: translate3d(2px, 2px, 0);
-          clip-path: inset(60% 0 0 0);
+          opacity: 0.8;
+          transform: translate3d(4px, 3px, 0);
+          clip-path: inset(55% 0 0 0);
         }
       }
     </style>
@@ -659,8 +659,8 @@
         const BUBBLE_INTERVAL = 4000; // ms between spawns
         const BUBBLE_JITTER = 1000; // ms random jitter
         const BUBBLE_DURATION = 5000; // ms visible
-        const LOGO_GLITCH_INTERVAL = 14000; // ms between glitch triggers
-        const LOGO_GLITCH_JITTER = 5000; // ms random offset
+        const LOGO_GLITCH_INTERVAL = 9000; // ms between glitch triggers
+        const LOGO_GLITCH_JITTER = 3000; // ms random offset
         const LOGO_GLITCH_DURATION = 1100; // ms animation length
         const TIP_DISCLAIMER =
           "\n\n<em>Ensure safe for care labels and understand restrictions. ATTEMPT AT YOUR OWN RISK – we are not responsible for any damage you cause to your garment.</em>";


### PR DESCRIPTION
## Summary
- amplify the logo and cannon glitch keyframes with larger offsets and opacity for more visible flashes
- reduce the glitch interval and jitter so the effect plays a bit more often on the attract screen and in-game

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31647f904832283f935f504cf58af