### PR TITLE
Fix cannon placement bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1044,10 +1044,7 @@
         }
 
         function moveCannonToRandomCorner() {
-          const choice =
-            CANNON_CORNER_CLASSES[
-              Math.floor(Math.random() * CANNON_CORNER_CLASSES.length)
-            ];
+          const choice = "glitch-cannon--bottom-right";
           CANNON_CORNER_CLASSES.forEach((cls) => cannon.classList.remove(cls));
           cannon.classList.add(choice);
           requestAnimationFrame(pointCannonAtCenter);


### PR DESCRIPTION
## Summary
- ensure the game cannon always repositions to the bottom-right corner when a round begins, fixing the top-left placement bug

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d31bef3088832294ce7a120d5a836f