### PR TITLE
Reflow attract screen layout to keep logo fully visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,105 +671,111 @@
     <!-- Attract / Start Screen -->
     <div
       id="startScreen"
-      class="absolute inset-0 flex flex-col items-center justify-start md:justify-center gap-12 bg-gradient-to-b from-emerald-50 via-white to-white touch-none select-none px-6 pt-24 pb-16 md:pt-28 md:pb-20 overflow-y-auto"
+      class="absolute inset-0 flex flex-col items-center justify-start lg:justify-center gap-12 bg-gradient-to-b from-emerald-50 via-white to-white touch-none select-none px-6 pt-24 pb-16 md:pt-28 md:pb-20 overflow-y-auto"
     >
-      <div class="w-full max-w-3xl">
-        <div
-          class="flex flex-col items-center gap-6 rounded-[32px] border border-emerald-100/70 bg-white/90 px-8 pt-12 pb-10 shadow-[0_25px_60px_rgba(16,185,129,0.18)] backdrop-blur-sm md:px-12"
-        >
-          <div class="w-full flex justify-center">
+      <div class="w-full max-w-6xl flex flex-col items-center gap-12 xl:flex-row xl:items-start xl:justify-center xl:gap-16">
+        <div class="flex-1 max-w-3xl flex flex-col items-center gap-8">
+          <div class="w-full">
             <div
-              id="logo"
-              class="glitch-shell relative w-64 sm:w-72 md:w-80 max-w-sm drop-shadow-2xl transition-transform duration-700 ease-out"
+              class="flex flex-col items-center gap-6 rounded-[32px] border border-emerald-100/70 bg-white/90 px-8 pt-12 pb-10 shadow-[0_25px_60px_rgba(16,185,129,0.18)] backdrop-blur-sm md:px-12"
             >
-              <img
-                src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
-                alt="Dublin Cleaners"
-                class="glitch-main"
-              />
-              <img
-                src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
-                alt=""
-                aria-hidden="true"
-                class="glitch-layer glitch-layer--red"
-              />
-              <img
-                src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
-                alt=""
-                aria-hidden="true"
-                class="glitch-layer glitch-layer--cyan"
-              />
+              <div class="w-full flex justify-center">
+                <div
+                  id="logo"
+                  class="glitch-shell relative w-64 sm:w-72 md:w-80 max-w-sm drop-shadow-2xl transition-transform duration-700 ease-out"
+                >
+                  <img
+                    src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
+                    alt="Dublin Cleaners"
+                    class="glitch-main"
+                  />
+                  <img
+                    src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
+                    alt=""
+                    aria-hidden="true"
+                    class="glitch-layer glitch-layer--red"
+                  />
+                  <img
+                    src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png"
+                    alt=""
+                    aria-hidden="true"
+                    class="glitch-layer glitch-layer--cyan"
+                  />
+                </div>
+              </div>
+              <div class="text-center">
+                <div class="text-5xl font-black tracking-tight text-emerald-900">
+                  Stain Blaster
+                </div>
+                <div class="mt-4 text-lg md:text-xl text-emerald-700/80">
+                  Swipe the stains away in 12 seconds for cleaning tips, prizes,
+                  and exclusive Dublin Cleaners discounts.
+                </div>
+              </div>
             </div>
           </div>
-          <div class="text-center">
-            <div class="text-5xl font-black tracking-tight text-emerald-900">
-              Stain Blaster
+          <div class="text-xl text-stone-500 text-center max-w-2xl">
+            Tap every stain off this shirt in 12 seconds to keep the garment
+            spotless and your prize streak alive!
+          </div>
+          <div class="flex flex-col items-center gap-3">
+            <div class="bubble-wow">
+              <img
+                src="https://www.dublincleaners.com/wp-content/uploads/2025/10/bubble.png"
+                alt="Glowing soap bubble"
+                class="bubble-wow__image"
+              />
+              <div
+                class="bubble-wow__sparkle bubble-wow__sparkle--one"
+                aria-hidden="true"
+              ></div>
+              <div
+                class="bubble-wow__sparkle bubble-wow__sparkle--two"
+                aria-hidden="true"
+              ></div>
+              <div
+                class="bubble-wow__sparkle bubble-wow__sparkle--three"
+                aria-hidden="true"
+              ></div>
+              <button
+                id="playBtn"
+                class="bubble-wow__button px-8 py-4 text-2xl shadow-lg focus:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200"
+              >
+                Pop to Play!
+              </button>
             </div>
-            <div class="mt-4 text-lg md:text-xl text-emerald-700/80">
-              Swipe the stains away in 12 seconds for cleaning tips, prizes, and
-              exclusive Dublin Cleaners discounts.
+            <div class="bubble-wow__caption text-emerald-700 text-xs md:text-sm font-semibold text-center">
+              Tap the magic bubble to launch the suds cannon
             </div>
           </div>
         </div>
-      </div>
-      <div class="text-xl text-stone-500 text-center">
-        Tap every stain off this shirt in 12 seconds to keep the garment
-        spotless and your prize streak alive!
-      </div>
-      <div class="grid gap-3 text-base text-stone-600 text-left max-w-xl px-4">
-        <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
-          <span class="text-2xl mr-2">🧼</span>
-          Race the timer and blast each splatter—no rule changes, just a sudsy
-          remix of the classic challenge you know.
+        <div class="flex-1 w-full max-w-xl flex flex-col items-center xl:items-stretch gap-6">
+          <div class="grid gap-3 text-base text-stone-600 text-left w-full">
+            <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
+              <span class="text-2xl mr-2">🧼</span>
+              Race the timer and blast each splatter—no rule changes, just a
+              sudsy remix of the classic challenge you know.
+            </div>
+            <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
+              <span class="text-2xl mr-2">🎯</span>
+              Build streaks to flex your skills and unlock bigger bragging
+              rights while the difficulty ramps up each win.
+            </div>
+            <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
+              <span class="text-2xl mr-2">💥</span>
+              Watch for surprise soap bars—snag one for a bubbly boost without
+              breaking the odds or prize tables.
+            </div>
+          </div>
+          <div class="text-xs text-stone-400 text-center xl:text-left w-full">
+            Disclaimer<br />
+            By pressing "Play Now", you understand this content provides general
+            fabric care tips only. Always follow the care labels on your
+            garments and be aware of any restrictions. Use these tips at your
+            own risk—Dublin Cleaners is not responsible for any damage that may
+            result from misuse or disregard of proper care instructions.
+          </div>
         </div>
-        <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
-          <span class="text-2xl mr-2">🎯</span>
-          Build streaks to flex your skills and unlock bigger bragging rights
-          while the difficulty ramps up each win.
-        </div>
-        <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
-          <span class="text-2xl mr-2">💥</span>
-          Watch for surprise soap bars—snag one for a bubbly boost without
-          breaking the odds or prize tables.
-        </div>
-      </div>
-      <div class="flex flex-col items-center gap-3">
-        <div class="bubble-wow">
-          <img
-            src="https://www.dublincleaners.com/wp-content/uploads/2025/10/bubble.png"
-            alt="Glowing soap bubble"
-            class="bubble-wow__image"
-          />
-          <div
-            class="bubble-wow__sparkle bubble-wow__sparkle--one"
-            aria-hidden="true"
-          ></div>
-          <div
-            class="bubble-wow__sparkle bubble-wow__sparkle--two"
-            aria-hidden="true"
-          ></div>
-          <div
-            class="bubble-wow__sparkle bubble-wow__sparkle--three"
-            aria-hidden="true"
-          ></div>
-          <button
-            id="playBtn"
-            class="bubble-wow__button px-8 py-4 text-2xl shadow-lg focus:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200"
-          >
-            Pop to Play!
-          </button>
-        </div>
-        <div class="bubble-wow__caption text-emerald-700 text-xs md:text-sm font-semibold text-center">
-          Tap the magic bubble to launch the suds cannon
-        </div>
-      </div>
-      <div class="text-xs text-stone-400 text-center max-w-md px-4">
-        Disclaimer<br />
-        By pressing "Play Now", you understand this content provides general
-        fabric care tips only. Always follow the care labels on your garments
-        and be aware of any restrictions. Use these tips at your own risk—Dublin
-        Cleaners is not responsible for any damage that may result from misuse
-        or disregard of proper care instructions.
       </div>
       <div
         id="attractCannon"


### PR DESCRIPTION
## Summary
- reorganize the attract screen into a flexible two-column layout on large displays so the Dublin Cleaners logo stays fully in view
- group the hero card, tagline, and play button together while moving instructions and the disclaimer into their own column for better balance

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_b_68e03cb14e04832e80e3fd8c5d58e88c