### PR TITLE
Fix duplicated start screen content

### DIFF
--- a/index.html
+++ b/index.html
@@ -734,7 +734,7 @@
             spotless and your prize streak alive!
           </div>
           <div class="flex flex-col items-center gap-3">
-            <div class="bubble-wow">
+            <div class="bubble-wow" id="playBubble">
               <img
                 src="https://www.dublincleaners.com/wp-content/uploads/2025/10/bubble.png"
                 alt="Glowing soap bubble"
@@ -791,65 +791,6 @@
             result from misuse or disregard of proper care instructions.
           </div>
         </div>
-      </div>
-      <div class="text-xl text-stone-500 text-center">
-        Tap every stain off this shirt in 12 seconds to keep the garment
-        spotless and your prize streak alive!
-      </div>
-      <div class="grid gap-3 text-base text-stone-600 text-left max-w-xl px-4">
-        <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
-          <span class="text-2xl mr-2">🧼</span>
-          Race the timer and blast each splatter—no rule changes, just a sudsy
-          remix of the classic challenge you know.
-        </div>
-        <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
-          <span class="text-2xl mr-2">🎯</span>
-          Build streaks to flex your skills and unlock bigger bragging rights
-          while the difficulty ramps up each win.
-        </div>
-        <div class="rounded-2xl bg-emerald-50/90 px-5 py-3 shadow-inner">
-          <span class="text-2xl mr-2">💥</span>
-          Watch for surprise soap bars—snag one for a bubbly boost without
-          breaking the odds or prize tables.
-        </div>
-      </div>
-      <div class="flex flex-col items-center gap-3">
-        <div class="bubble-wow" id="playBubble">
-          <img
-            src="https://www.dublincleaners.com/wp-content/uploads/2025/10/bubble.png"
-            alt="Glowing soap bubble"
-            class="bubble-wow__image"
-          />
-          <div
-            class="bubble-wow__sparkle bubble-wow__sparkle--one"
-            aria-hidden="true"
-          ></div>
-          <div
-            class="bubble-wow__sparkle bubble-wow__sparkle--two"
-            aria-hidden="true"
-          ></div>
-          <div
-            class="bubble-wow__sparkle bubble-wow__sparkle--three"
-            aria-hidden="true"
-          ></div>
-          <button
-            id="playBtn"
-            class="bubble-wow__button px-8 py-4 text-2xl shadow-lg focus:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200"
-          >
-            Pop to Play!
-          </button>
-        </div>
-        <div class="bubble-wow__caption text-emerald-700 text-xs md:text-sm font-semibold text-center">
-          Tap the magic bubble to launch the suds cannon
-        </div>
-      </div>
-      <div class="text-xs text-stone-400 text-center max-w-md px-4">
-        Disclaimer<br />
-        By pressing "Play Now", you understand this content provides general
-        fabric care tips only. Always follow the care labels on your garments
-        and be aware of any restrictions. Use these tips at your own risk—Dublin
-        Cleaners is not responsible for any damage that may result from misuse
-        or disregard of proper care instructions.
       </div>
       <div
         id="attractCannon"


### PR DESCRIPTION
## Summary
- assign the Pop to Play bubble container an id so the whole bubble can start the round
- remove duplicated hero text, feature highlights, bubble, and disclaimer blocks that were showing twice on the attract screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e0580b2ba0832ea0c66461ad31371f