### PR TITLE
Center timer above gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,13 +471,15 @@
 
       #timerShell {
         position: absolute;
-        top: calc(env(safe-area-inset-top, 0px) + 1rem);
-        left: calc(env(safe-area-inset-left, 0px) + 1rem);
-        z-index: 30;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 120;
         display: flex;
         flex-direction: column;
-        align-items: flex-start;
-        gap: 0.35rem;
+        align-items: center;
+        gap: 0.5rem;
+        pointer-events: none;
       }
 
       #timerShell .timer-label {
@@ -490,6 +492,7 @@
         color: rgba(236, 253, 245, 0.9);
         background: rgba(13, 148, 136, 0.6);
         backdrop-filter: blur(4px);
+        text-align: center;
       }
 
       #timerShell #timer {


### PR DESCRIPTION
## Summary
- move the timer HUD to the center of the screen
- raise its z-index and disable pointer events so other elements cannot cover it

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_b_68e05b84e4b0832e8471d091700e16de