### PR TITLE
Adjust start screen spacing and bubble cadence

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,11 @@
         touch-action: none;
       }
 
+      #highScore {
+        top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
+        right: calc(env(safe-area-inset-right, 0px) + 0.75rem);
+      }
+
       #highScoreModal .kb-row {
         display: flex;
         flex-wrap: wrap;
@@ -1192,7 +1197,7 @@
           "Your dry-cleaner believes in you 😎",
           "Beat the Su-Stained High Score!!",
         ];
-        const BUBBLE_INTERVAL = 4000; // ms between spawns
+        const BUBBLE_INTERVAL = 5000; // ms between spawns (25% less frequent)
         const BUBBLE_JITTER = 1000; // ms random jitter
         const BUBBLE_DURATION = 5000; // ms visible
         const LOGO_GLITCH_INTERVAL = 9000; // ms between glitch triggers


### PR DESCRIPTION
## Summary
- offset the floating high-score badge using safe area insets so it is fully visible on kiosks
- slow the attract-mode chat bubble spawns by 25% to reduce on-screen noise

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_b_68e0614c31bc832eab3757c2d308656c