### PR TITLE
Boost soap power-up cleaning range

### DIFF
--- a/index.html
+++ b/index.html
@@ -1243,7 +1243,8 @@
         const POWERUP_MIN_DELAY = 3600; // ms
         const POWERUP_MAX_DELAY = 6800; // ms
         const POWERUP_LIFETIME = 4200; // ms soap visible
-        const POWERUP_MAX_CLEARS = 3;
+        const POWERUP_MIN_CLEARS = 4;
+        const POWERUP_MAX_CLEARS = 6;
         const SOAP_SLOW_DURATION = 2200; // ms pause on cannon
         const POWERUP_TOAST_DURATION = 2400; // ms toast visibility
         const BUBBLE_LINES = [
@@ -1692,7 +1693,10 @@
           activePowerUp = null;
           clearTimeout(powerUpLifetimeTimer);
           createFoamBurst(centerX, centerY);
-          const cleaned = cleanRandomStains(POWERUP_MAX_CLEARS);
+          const targetClears = Math.floor(
+            randomBetween(POWERUP_MIN_CLEARS, POWERUP_MAX_CLEARS + 1),
+          );
+          const cleaned = cleanRandomStains(targetClears);
           if (cleaned > 0) {
             showPowerupToast(
               `Foam burst! ${cleaned} stain${cleaned > 1 ? "s" : ""} scrubbed!`,


### PR DESCRIPTION
## Summary
- increase the soap power-up's stain clearing range to randomly clean between four and six stains
- adjust the activation logic to use the new randomized target for a stronger foam burst

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e0727c6df0832eae5f09cc82a63092