### PR TITLE
Prevent touch highlight on game elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,10 +139,32 @@
         }
       }
 
+      /* Prevent touch highlight/select behavior from interrupting gameplay */
+      :root {
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      #gameArea,
+      #gameArea * {
+        -webkit-tap-highlight-color: transparent;
+        -webkit-touch-callout: none;
+      }
+
+      #gameArea,
+      #gameArea *:not(input):not(textarea) {
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: manipulation;
+      }
+
       .stain {
         position: absolute;
         filter: drop-shadow(2px 2px 3px rgba(0, 0, 0, 0.4));
         z-index: 10;
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-user-drag: none;
       }
       .glitch-cannon {
         position: fixed;


### PR DESCRIPTION
## Summary
- disable tap highlight, text selection, and touch callouts on the game surface to avoid distracting blue overlays on touch devices
- ensure stain sprites stay draggable-free so taps only trigger stain removal

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_b_68e7bb7e9adc832e9f983a23463c5060