### PR TITLE
Optimize stain handling for smoother kiosk play

### DIFF
--- a/index.html
+++ b/index.html
@@ -1254,6 +1254,28 @@
             scoreRect.bottom - areaRect.top + HIGH_SCORE_CLEARANCE;
           return Math.max(base, clearance);
         }
+
+        function getSpawnMetrics() {
+          const rect = gameArea.getBoundingClientRect();
+          if (!rect.width || !rect.height) {
+            return {
+              rect,
+              topMargin: TOP_MARGIN,
+              spawnW: 0,
+              spawnH: 0,
+            };
+          }
+          const topMargin = computeTopMargin(rect);
+          return {
+            rect,
+            topMargin,
+            spawnW: Math.max(0, rect.width - STAIN_SIZE),
+            spawnH: Math.max(
+              0,
+              rect.height - STAIN_SIZE - topMargin - BOTTOM_MARGIN,
+            ),
+          };
+        }
         const STAIN_IMAGES = [
           "https://www.dublincleaners.com/wp-content/uploads/2025/08/Ketchup.png",
           "https://www.dublincleaners.com/wp-content/uploads/2025/08/Coffee.png",
@@ -1364,6 +1386,8 @@
           resultShown = false;
 
         const glitchTimers = new Map();
+
+        const activeStains = new Set();
 
         let activePowerUp = null;
         let isRoundActive = false;
@@ -1631,16 +1655,39 @@
           setTimeout(() => burst.remove(), 600);
         }
 
+        function removeStain(stain) {
+          if (!stain || !activeStains.has(stain)) {
+            return false;
+          }
+          activeStains.delete(stain);
+          stain.__removeStain = null;
+          if (stain.isConnected) {
+            stain.remove();
+          }
+          remaining = activeStains.size;
+          updateProgressDisplay();
+          if (isRoundActive && seconds > 0 && remaining === 0) {
+            win();
+          }
+          return true;
+        }
+
         function cleanRandomStains(maxCount) {
-          const stains = Array.from(gameArea.querySelectorAll(".stain"));
+          const stains = Array.from(activeStains);
           if (!stains.length) return 0;
           let cleaned = 0;
-          for (const stain of stains.sort(() => Math.random() - 0.5)) {
+          const limit = Math.min(maxCount, stains.length);
+          for (let i = 0; i < limit; i++) {
+            const swapIndex = i + Math.floor(Math.random() * (stains.length - i));
+            [stains[i], stains[swapIndex]] = [stains[swapIndex], stains[i]];
+            const stain = stains[i];
+            if (!stain) continue;
             if (typeof stain.__removeStain === "function") {
               stain.__removeStain();
               cleaned++;
+            } else if (removeStain(stain)) {
+              cleaned++;
             }
-            if (cleaned >= maxCount) break;
           }
           return cleaned;
         }
@@ -1667,21 +1714,22 @@
           if (activePowerUp && activePowerUp.isConnected) {
             return;
           }
-          const rect = gameArea.getBoundingClientRect();
+          const metrics = getSpawnMetrics();
+          const { rect, topMargin } = metrics;
           if (!rect.width || !rect.height) return;
           const soap = document.createElement("img");
           soap.src = SOAP_POWERUP_IMAGE;
           soap.alt = "Sudsy power-up";
           soap.className = "powerup";
           const soapSize = 86;
-          const topMargin = computeTopMargin(rect) + 30;
+          const soapTopMargin = topMargin + 30;
           const spawnW = Math.max(0, rect.width - soapSize);
           const spawnH = Math.max(
             0,
-            rect.height - soapSize - topMargin - BOTTOM_MARGIN,
+            rect.height - soapSize - soapTopMargin - BOTTOM_MARGIN,
           );
           const x = Math.random() * spawnW;
-          const y = Math.random() * spawnH + topMargin;
+          const y = Math.random() * spawnH + soapTopMargin;
           soap.style.left = `${x}px`;
           soap.style.top = `${y}px`;
           soap.style.width = `${soapSize}px`;
@@ -1707,7 +1755,13 @@
 
         function activateSoapPowerUp(soap) {
           if (activePowerUp !== soap) return;
-          const areaRect = gameArea.getBoundingClientRect();
+          const { rect: areaRect } = getSpawnMetrics();
+          if (!areaRect.width || !areaRect.height) {
+            soap.remove();
+            activePowerUp = null;
+            schedulePowerUp();
+            return;
+          }
           const soapRect = soap.getBoundingClientRect();
           const centerX = soapRect.left - areaRect.left + soapRect.width / 2;
           const centerY = soapRect.top - areaRect.top + soapRect.height / 2;
@@ -1929,45 +1983,51 @@
           });
         });
 
-        function spawnStain(x, y) {
-          const s = document.createElement("img");
-          s.src = randomImage();
-          s.className = "stain";
-          s.dataset.stain = "true";
-          const rect = gameArea.getBoundingClientRect();
-          const topMargin = computeTopMargin(rect);
-          const spawnW = Math.max(0, rect.width - STAIN_SIZE);
-          const spawnH = Math.max(
-            0,
-            rect.height - STAIN_SIZE - topMargin - BOTTOM_MARGIN,
-          );
-          if (x === undefined) {
-            x = Math.random() * spawnW;
+        function handleGameAreaPointerDown(event) {
+          const target = event.target;
+          if (!target) return;
+          const stain = target.closest ? target.closest(".stain") : null;
+          if (!stain || !gameArea.contains(stain)) return;
+          if (typeof stain.__removeStain === "function") {
+            stain.__removeStain();
+          } else {
+            removeStain(stain);
           }
-          if (y === undefined) {
-            y = Math.random() * spawnH + topMargin;
+        }
+
+        gameArea.addEventListener("pointerdown", handleGameAreaPointerDown);
+
+        function spawnStain(x, y, metrics) {
+          const spawnMetrics = metrics || getSpawnMetrics();
+          const { rect, topMargin, spawnW, spawnH } = spawnMetrics;
+          if (!rect.width || !rect.height) {
+            return null;
           }
-          s.style.left = x + "px";
-          s.style.top = y + "px";
-          s.style.width = STAIN_SIZE + "px";
-          s.style.height = STAIN_SIZE + "px";
-          s.style.transform = `rotate(${Math.random() * 360}deg)`;
-          const remove = () => {
-            if (!s.isConnected) return;
-            s.removeEventListener("pointerdown", remove);
-            s.remove();
-            s.__removeStain = null;
-            remaining = Math.max(0, (remaining || 0) - 1);
-            updateProgressDisplay();
-            if (remaining === 0 && seconds > 0) win();
-          };
-          s.addEventListener("pointerdown", remove);
-          s.__removeStain = remove;
-          gameArea.appendChild(s);
-          remaining = (remaining || 0) + 1;
+          const stain = document.createElement("img");
+          stain.src = randomImage();
+          stain.className = "stain";
+          stain.dataset.stain = "true";
+          let nextX = x;
+          let nextY = y;
+          if (typeof nextX !== "number") {
+            nextX = Math.random() * spawnW;
+          }
+          if (typeof nextY !== "number") {
+            nextY = Math.random() * spawnH + topMargin;
+          }
+          stain.style.left = nextX + "px";
+          stain.style.top = nextY + "px";
+          stain.style.width = STAIN_SIZE + "px";
+          stain.style.height = STAIN_SIZE + "px";
+          stain.style.transform = `rotate(${Math.random() * 360}deg)`;
+          const remove = () => removeStain(stain);
+          stain.__removeStain = remove;
+          activeStains.add(stain);
+          gameArea.appendChild(stain);
+          remaining = activeStains.size;
           total = (total || 0) + 1;
           updateProgressDisplay();
-          return s;
+          return stain;
         }
 
         function animateProjectile(el, x0, y0, x1, y1) {
@@ -1991,16 +2051,12 @@
         }
 
         function fireCannon() {
-          const area = gameArea.getBoundingClientRect();
+          const metrics = getSpawnMetrics();
+          const { rect, topMargin, spawnW, spawnH } = metrics;
+          if (!rect.width || !rect.height) return;
           const { areaX: mouthX, areaY: mouthY } = getCannonMouthPosition(
             cannon,
-            area,
-          );
-          const topMargin = computeTopMargin(area);
-          const spawnW = Math.max(0, area.width - STAIN_SIZE);
-          const spawnH = Math.max(
-            0,
-            area.height - STAIN_SIZE - topMargin - BOTTOM_MARGIN,
+            rect,
           );
           const targetX = Math.random() * spawnW;
           const targetY = Math.random() * spawnH + topMargin;
@@ -2008,8 +2064,9 @@
           const offset = 30;
           const startX = mouthX + Math.cos(angle) * offset;
           const startY = mouthY + Math.sin(angle) * offset;
-          const s = spawnStain(startX, startY);
-          animateProjectile(s, startX, startY, targetX, targetY);
+          const stain = spawnStain(startX, startY, metrics);
+          if (!stain) return;
+          animateProjectile(stain, startX, startY, targetX, targetY);
           pointCannonAtCenter();
         }
 
@@ -2050,7 +2107,13 @@
           resetCannonPosition();
           triggerLogoGlitch();
           scheduleLogoGlitch(0);
-          gameArea.querySelectorAll(".stain").forEach((s) => s.remove());
+          for (const stain of activeStains) {
+            stain.__removeStain = null;
+            if (stain.isConnected) {
+              stain.remove();
+            }
+          }
+          activeStains.clear();
           if (!gameArea.contains(timerEl)) gameArea.appendChild(timerEl);
           remaining = 0;
           total = 0;
@@ -2059,7 +2122,10 @@
           highScoreEl.classList.remove("hidden");
           updateStreakBadge();
           updateProgressDisplay();
-          for (let i = 0; i < STAIN_START; i++) spawnStain();
+          const spawnMetrics = getSpawnMetrics();
+          for (let i = 0; i < STAIN_START; i++) {
+            spawnStain(undefined, undefined, spawnMetrics);
+          }
           seconds = GAME_TIME;
           timerEl.textContent = seconds;
           startTime = now();
@@ -2081,7 +2147,8 @@
           clearInterval(countdown);
           clearInterval(fireInterval);
           // Double-check no stain elements remain before allowing a win
-          const stainsLeft = gameArea.querySelectorAll(".stain").length;
+          const stainsLeft = activeStains.size ||
+            gameArea.querySelectorAll(".stain").length;
           showResult(stainsLeft === 0);
         }
 
@@ -2271,6 +2338,16 @@
           resultShown = false;
           applyCannonCorner(attractCannon);
           requestAnimationFrame(pointAttractCannonIdle);
+          for (const stain of activeStains) {
+            stain.__removeStain = null;
+            if (stain.isConnected) {
+              stain.remove();
+            }
+          }
+          activeStains.clear();
+          total = 0;
+          remaining = 0;
+          updateProgressDisplay();
           if (pendingHighScore !== null) {
             skipHighScoreName();
           } else {


### PR DESCRIPTION
## Summary
- reuse cached spawn measurements when creating stains and power-ups to reduce layout thrash
- delegate stain input handling and maintain an active stain set for lighter interactions and progress tracking
- reset stain state between rounds so the meter and win logic stay consistent on kiosk hardware

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e7c0fd9334832e971ed2e6cd16001d